### PR TITLE
Removes tp-provisioner-agent helm hooks

### DIFF
--- a/charts/dp-core-infrastructure/charts/tp-provisioner-agent/templates/ingress.yaml
+++ b/charts/dp-core-infrastructure/charts/tp-provisioner-agent/templates/ingress.yaml
@@ -7,8 +7,6 @@ metadata:
   {{- include "tp-provisioner-agent.shared.labels.standard" . | nindent 4 }}
   annotations:
     ingress.kubernetes.io/path-rewrite: "/tibco/agent/infra/provisioner-agent/(.*) /\\1"
-    "helm.sh/hook": post-install, post-upgrade # using post install hooks to create ingress rule. the post-upgrade hook is debatable as this would the ingress rule gets recreated in each upgrade.
-    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   ingressClassName: tibco-dp-{{ .Values.global.tibco.dataPlaneId}}
   rules:


### PR DESCRIPTION
## Change
Removes `helm.sh/hook` and `helm.sh/hook-delete-policy` from the `tp-provisioner-agent/ingress`
This change doesn't impact the installation of the helm chart from scratch nor its updates as tested locally

## Issue
This allows GitOps tool as ArgoCD to successfully deploy this helm chart as that would be impossible with current setup.

With the current configuration, ArgoCD will wait until all of the items are successfully synced and healthy before creating the Ingress resource. That will never happen though as the tp-tunnel would not be healthy until the ingress is created and is reachable.