### PR TITLE
OAuth2 proxy charts published for 1.8.0 release.

### DIFF
--- a/charts/oauth2-proxy-manifests/Chart.yaml
+++ b/charts/oauth2-proxy-manifests/Chart.yaml
@@ -3,11 +3,11 @@
 # in the license file that is distributed with this file.
 
 name: oauth2-proxy
-# Original oauth2-proxy chart version: 6.17.0
-# Original oauth2-proxy version: 7.5.1
-version: 10.2.12
+# Original oauth2-proxy chart version: 1.8.2
+# Original oauth2-proxy version: 10.2.15
+version: 10.2.16
 apiVersion: v2
-appVersion: 1.7.0
+appVersion: 1.8.2
 
 home: https://oauth2-proxy.github.io/oauth2-proxy/
 description: A reverse proxy that provides authentication with Google, Github or other providers

--- a/charts/oauth2-proxy-manifests/values.yaml
+++ b/charts/oauth2-proxy-manifests/values.yaml
@@ -72,7 +72,7 @@ alphaConfig:
 
 image:
   name: core-tp-oauth-proxy
-  tag: "v1.7.2"
+  tag: "v1.8.0"
   pullPolicy: "IfNotPresent"
   # appVersion is used by default
 
@@ -481,7 +481,7 @@ global:
       fluentbit:
         image:
           name: common-fluentbit
-          tag: "4.0.0"
+          tag: "4.0.3"
         enabled: true
         resources:
           requests:

--- a/charts/oauth2-proxy-recipes/Chart.yaml
+++ b/charts/oauth2-proxy-recipes/Chart.yaml
@@ -6,8 +6,8 @@ apiVersion: v2
 name: dp-oauth2proxy-recipes
 description: TIBCO Platform OAuth2 Proxy Data Plane recipes
 type: application
-version: 1.7.6
-appVersion: "1.7.0"
+version: 1.8.3
+appVersion: "1.8.0"
 keywords:
   - tibco-platform
   - control-plane

--- a/charts/oauth2-proxy-recipes/templates/oauth2proxy.yaml
+++ b/charts/oauth2-proxy-recipes/templates/oauth2proxy.yaml
@@ -12,7 +12,7 @@ metadata:
 data:
   version.json: |
     {
-      "capabilityVersion": "1.7.0",
+      "capabilityVersion": "1.8.0",
       "minCPVersion": "1.1.0",
       "maxCPVersion": "",
       "releaseDate": {{ .Values.capabilities.oauth2proxy.releaseDate | quote }},
@@ -126,7 +126,7 @@ spec:
         - name: RECIPE_TARGET_LOCATION
           value: "/private/tsc/config/capabilities/infra_sidecar"
         - name: RECIPE_RELEASE_VERSION
-          value: "1.7.0"
+          value: "1.8.0"
         - name: SPACE_SEPARATED_UNSUPPORTED_RECIPE_VERSIONS
           value: ""
         - name: OVERWRITE_RECIPE

--- a/charts/oauth2-proxy-recipes/values.yaml
+++ b/charts/oauth2-proxy-recipes/values.yaml
@@ -9,8 +9,8 @@ capabilities:
     # set to true for latest version of recipe
     isLatest: "true"
     # Helm chart version for oauth2 proxy, default is latest
-    version: "10.2.12"
-    tag: "v1.7.2"
+    version: "10.2.16"
+    tag: "v1.8.0"
     # Timestamp of capability release
     releaseDate: "2025/05/01"
     # Either a link to document or the document itself specifying _what was fixed in this release.


### PR DESCRIPTION
OAuth2 proxy charts published for 1.8.0 release.