### PR TITLE
o11y-1-10-0: promote o11y-service chart

### DIFF
--- a/charts/o11y-service/Chart.yaml
+++ b/charts/o11y-service/Chart.yaml
@@ -5,6 +5,6 @@
 #
 apiVersion: v2
 name: o11yservice
-version: 1.10.5
+version: 1.10.6
 appVersion: "1.10.0"
 description: A helm chart for o11y service

--- a/charts/o11y-service/values.yaml
+++ b/charts/o11y-service/values.yaml
@@ -441,7 +441,7 @@ global:
       namespace: dp-integration-default
     image:
       registry: 664529841144.dkr.ecr.us-west-2.amazonaws.com
-      tag: 3000
+      tag: 3077
 
 
 replicaCount: 1


### PR DESCRIPTION
This pull request includes minor version updates for the o11y-service Helm chart. The changes update the chart version and the container image tag to ensure the deployment uses the latest image.

* Chart version bump:
  * Updated the `version` field in `charts/o11y-service/Chart.yaml` from `1.10.5` to `1.10.6` to reflect a new release.

* Container image update:
  * Changed the `global.image.tag` value in `charts/o11y-service/values.yaml` from `3000` to `3077` to deploy a newer image version.