### PR TITLE
promote-cp-proxy: update chart version and values

### DIFF
--- a/charts/tp-cp-proxy/Chart.yaml
+++ b/charts/tp-cp-proxy/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 1.10.0
+appVersion: 1.11.0
 description: A Helm chart for Control Plane Proxy
 keywords:
 - cp-proxy
 - data-plane
 name: tp-cp-proxy
-version: 1.10.2
+version: 1.11.2

--- a/charts/tp-cp-proxy/values.yaml
+++ b/charts/tp-cp-proxy/values.yaml
@@ -30,7 +30,7 @@ replicaCount: "1"
 
 image:
   name: infra-cp-proxy
-  tag: 255
+  tag: 272
   pullPolicy: IfNotPresent
 
 nodeSelector:
@@ -69,7 +69,7 @@ global:
         enabled: true
         image:
           name: common-fluentbit
-          tag: 4.0.3
+          tag: 4.0.8
         # Resources
         # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         resources:


### PR DESCRIPTION
This pull request updates the Helm chart for the Control Plane Proxy to use newer versions of the application and its related images. The main changes are version bumps to ensure the deployment uses the latest features and fixes.

Version updates:

* Increased `appVersion` to `1.11.0` and chart `version` to `1.11.2` in `Chart.yaml` to reflect the new release.
* Updated the main image tag for `infra-cp-proxy` to `272` in `values.yaml`, ensuring the deployment uses the latest container image.

Dependency updates:

* Updated the `common-fluentbit` image tag to `4.0.8` in the global configuration in `values.yaml` for improved logging support.