### PR TITLE
platform base 1.11.1 chart promotion

### DIFF
--- a/charts/platform-base/Chart.yaml
+++ b/charts/platform-base/Chart.yaml
@@ -8,8 +8,8 @@ apiVersion: v2
 name: platform-base
 description: TIBCO Platform base chart
 type: application
-version: 1.11.0
-appVersion: "1.11.0"
+version: 1.11.1
+appVersion: "1.11.1"
 keywords:
   - tibco-platform
   - platform

--- a/charts/platform-base/charts/tp-cp-infra/values.yaml
+++ b/charts/platform-base/charts/tp-cp-infra/values.yaml
@@ -66,7 +66,7 @@ hpa:
 image:
   infra-compute-services:
     name: infra-compute-services
-    tag: 639-distroless
+    tag: 645-distroless
     pullPolicy: IfNotPresent
   infra-alerts-services:
     name: infra-alerts-service


### PR DESCRIPTION
This pull request updates the Helm chart version for the platform base and bumps the image tag for the infra compute services. These changes ensure that deployments use the latest application version and container image.

Version updates:

* Updated the `version` and `appVersion` fields in `charts/platform-base/Chart.yaml` from `1.11.0` to `1.11.1`, reflecting a new release of the platform base chart.

Image updates:

* Changed the `infra-compute-services` image tag in `charts/platform-base/charts/tp-cp-infra/values.yaml` from `639-distroless` to `645-distroless` to use a newer container image.