### PR TITLE
1.16.0 base chart promotion

### DIFF
--- a/artifacts/control-plane/control-plane-1.16.0-charts.txt
+++ b/artifacts/control-plane/control-plane-1.16.0-charts.txt
@@ -2,9 +2,9 @@ artifactmanager:1.16.0
 dp-configure-namespace:1.16.0
 dp-core-infrastructure:1.16.4
 jaeger:0.72.40
-o11yservice:1.16.6
+o11yservice:1.16.10
 opentelemetry-collector:0.140.3
-tibco-cp-base:1.16.0-alpha.64
+tibco-cp-base:1.16.0
 tp-cp-proxy:1.16.3
 tp-dp-license-file:1.13.0
 tp-dp-monitor-agent:1.16.230

--- a/artifacts/control-plane/control-plane-1.16.0-images.txt
+++ b/artifacts/control-plane/control-plane-1.16.0-images.txt
@@ -8,8 +8,8 @@ core-identity-provider:1068
 core-orchestrator:6804
 core-pengine:1626
 core-user-subscriptions:2917
-core-web-server:8638
-hawk-prometheus-discoveryservice:1.16.0.4
+core-web-server:8684
+hawk-prometheus-discoveryservice:1.16.0.6
 infra-alertmanager:v0.31.1
 infra-alerts-service:190-distroless
 infra-artifactmanager:149
@@ -32,7 +32,7 @@ o11y-jaeger-query:1.66.0
 o11y-mcp-service:186
 o11y-opentelemetry-collector-contrib:0.140.0
 o11y-opentelemetry-collector-contrib:0.119.0
-o11y-service:3940
+o11y-service:3965
 o11y-tas-web-server:638
 tel-monitor-agent:381
 tel-monitoring-service:707

--- a/charts/tibco-cp-base/Chart.yaml
+++ b/charts/tibco-cp-base/Chart.yaml
@@ -8,8 +8,8 @@ apiVersion: v2
 name: tibco-cp-base
 description: TIBCO Platform base chart
 type: application
-version: 1.15.0
-appVersion: "1.15.0"
+version: 1.16.0-alpha.70
+appVersion: "1.16.0"
 keywords:
   - tibco-platform
   - platform
@@ -19,42 +19,38 @@ annotations:
   app.helm.sh/name: tibco-cp-base
 dependencies:
   - name: tp-cp-infra
-    version: "1.15.*"
-    condition: tp-cp-infra.enabled
+    version: "1.16.*"
   - name: hybrid-proxy
-    version: "1.15.*"
+    version: "1.16.*"
     condition: global.tibco.hybridConnectivity.enabled
   - name: resource-set-operator
-    version: "1.15.*"
+    version: "1.16.*"
     condition: global.tibco.hybridConnectivity.enabled
   - name: router-operator
-    version: "1.15.*"
-    condition: router-operator.enabled
+    version: "1.16.*"
   - name: otel-collector
     version: "0.116.*"
     condition: otel-collector.enabled
-  - name: tp-cp-o11y
-    version: "1.15.*"
-    condition: tp-cp-o11y.enabled
   - name: tp-cp-configuration
-    version: "1.15.*"
+    version: "1.16.*"
   - name: tp-cp-core
-    version: "1.15.*"
+    version: "1.16.*"
   - name: tp-cp-core-finops
-    version: "1.15.*"
+    version: "1.16.*"
+  - name: tp-cp-o11y
+    version: "1.16.*"
+    condition: tp-cp-o11y.enabled
   - name: tp-cp-integration-common
-    version: "1.13.*"
+    version: "1.16.*"
     condition: tp-cp-integration-common.enabled
   - name: tp-cp-cli
-    version: "1.6.*"
+    version: "1.7.*"
     condition: tp-cp-cli.enabled
   - name: tp-cp-alertmanager
-    version: "1.15.*"
+    version: "1.16.*"
   - name: tp-cp-prometheus
-    version: "1.15.*"
+    version: "1.16.*"
   - name: tp-cp-auditsafe
-    version: "1.15.*"
-    condition: tp-cp-auditsafe.enabled
+    version: "1.16.*"
   - name: tp-dp-proxy
-    version: "1.15.*"
-    condition: tp-dp-proxy.enabled
+    version: "1.16.*"

--- a/charts/tibco-cp-base/Chart.yaml
+++ b/charts/tibco-cp-base/Chart.yaml
@@ -8,7 +8,7 @@ apiVersion: v2
 name: tibco-cp-base
 description: TIBCO Platform base chart
 type: application
-version: 1.16.0-alpha.70
+version: 1.16.0
 appVersion: "1.16.0"
 keywords:
   - tibco-platform

--- a/charts/tibco-cp-base/charts/hybrid-proxy/Chart.yaml
+++ b/charts/tibco-cp-base/charts/hybrid-proxy/Chart.yaml
@@ -7,6 +7,6 @@
 
 apiVersion: v2
 name: hybrid-proxy
-version: 1.15.0
-appVersion: "1.15.0"
+version: 1.16.0
+appVersion: "1.16.0"
 description: TIBCO Platform cp core bootstrap -- Hybrid Proxy operator

--- a/charts/tibco-cp-base/charts/hybrid-proxy/templates/deployment.yaml
+++ b/charts/tibco-cp-base/charts/hybrid-proxy/templates/deployment.yaml
@@ -105,7 +105,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["/bin/bash", "-c", "sleep 300"] # allow some time to complete in-flight API calls and to have new NLB targets become healthy
+              command: ["/busybox/sleep", "300"] # allow some time to complete in-flight API calls and to have new NLB targets become healthy
         env:
         - name: WAIT_FOR_BACKEND_POD_TO_BE_READY
           value: "{{ .Values.waitForBackendPodToBeReady }}"
@@ -152,8 +152,8 @@ spec:
 {{- end }}
 {{- if .Values.global.tibco.logging.fluentbit.enabled }}
       - name: fluentbit
-        image: {{ include "hybrid-proxy.image.registry" .}}{{"/"}}{{ include "hybrid-proxy.image.repository" .}}{{"/"}}{{ .Values.global.tibco.logging.fluentbit.image.name }}:{{ .Values.global.tibco.logging.fluentbit.image.tag }}
-        imagePullPolicy: {{ .Values.global.tibco.logging.fluentbit.image.pullPolicy }}
+        image: {{ include "hybrid-proxy.image.registry" .}}{{"/"}}{{ include "hybrid-proxy.image.repository" .}}{{"/common-fluentbit"}}:{{ .Values.global.tibco.commonImages.fluentbit.tag }}
+        imagePullPolicy: IfNotPresent
         {{- if .Values.securityContext }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}

--- a/charts/tibco-cp-base/charts/hybrid-proxy/values.yaml
+++ b/charts/tibco-cp-base/charts/hybrid-proxy/values.yaml
@@ -40,7 +40,7 @@ hpa:
 
 image:
   name: infra-hybrid-proxy
-  tag: 107-distroless
+  tag: 111-distroless
   pullPolicy: IfNotPresent
 
 ports:
@@ -133,7 +133,7 @@ ingress:
 
 # Gateway API HTTPRoute configuration (gateway.networking.k8s.io/v1)
 # This provides native Gateway API support for NGINX Gateway Fabric and other Gateway API implementations
-#
+# 
 # IMPORTANT: Gateway API CRDs must be installed in the cluster before enabling this feature
 # Install with: kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/standard-install.yaml
 #
@@ -196,27 +196,6 @@ global:
     # control plane instance Id. Ex: prod, stag, p01, s01. This is to identify multiple cp installation in same cluster.
     # lowercase alphanumeric string of max 5 chars
     controlPlaneInstanceId: ""
-
-    # The fluentbit configuration section.
-    # It specifies that the fluentbit should not run as a non-root user and the user ID should be 0 (root).
-    # Privilege escalation is not allowed for security reasons.
-    # Additionally, it drops all capabilities, which is a common security practice to minimize potential risks.
-    logging:
-      fluentbit:
-        enabled: true
-        image:
-          name: "common-fluentbit"
-          registry: ""
-          repo: ""
-          tag: 4.2.2
-          pullPolicy: IfNotPresent
-        resources:
-          requests:
-            cpu: 50m
-            memory: 100Mi
-          limits:
-            cpu: 100m
-            memory: 150Mi
 
   external:
     dnsTunnelDomain: ""

--- a/charts/tibco-cp-base/charts/resource-set-operator/Chart.yaml
+++ b/charts/tibco-cp-base/charts/resource-set-operator/Chart.yaml
@@ -7,6 +7,6 @@
 
 apiVersion: v2
 name: resource-set-operator
-version: 1.15.0
-appVersion: "1.15.0"
+version: 1.16.0
+appVersion: "1.16.0"
 description: TIBCO Platform cp core bootstrap  -- Resource Set Operator

--- a/charts/tibco-cp-base/charts/resource-set-operator/templates/deployment.yaml
+++ b/charts/tibco-cp-base/charts/resource-set-operator/templates/deployment.yaml
@@ -129,8 +129,8 @@ spec:
             mountPath: "/etc/config"
 {{- if .Values.global.tibco.logging.fluentbit.enabled }}
       - name: fluentbit
-        image: {{ include "resource-set-operator.image.registry" .}}{{"/"}}{{ include "resource-set-operator.image.repository" .}}{{"/"}}{{ .Values.global.tibco.logging.fluentbit.image.name }}:{{ .Values.global.tibco.logging.fluentbit.image.tag }}
-        imagePullPolicy: {{ .Values.global.tibco.logging.fluentbit.image.pullPolicy }}
+        image: {{ include "resource-set-operator.image.registry" .}}{{"/"}}{{ include "resource-set-operator.image.repository" .}}{{"/common-fluentbit"}}:{{ .Values.global.tibco.commonImages.fluentbit.tag }}
+        imagePullPolicy: IfNotPresent
         {{- if .Values.securityContext }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}

--- a/charts/tibco-cp-base/charts/resource-set-operator/values.yaml
+++ b/charts/tibco-cp-base/charts/resource-set-operator/values.yaml
@@ -26,7 +26,7 @@ settingsConfigmap:
 
 image:
   name: infra-resource-set-operator
-  tag: 356-distroless
+  tag: 361-distroless
   pullPolicy: IfNotPresent
 
 # no of replicas
@@ -65,25 +65,3 @@ global:
     # control plane instance Id. Ex: prod, stag, p01, s01. This is to identify multiple cp installation in same cluster.
     # lowercase alphanumeric string of max 5 chars
     controlPlaneInstanceId: ""
-
-    # The fluentbit configuration section.
-    # It specifies that the fluentbit should not run as a non-root user and the user ID should be 0 (root).
-    # Privilege escalation is not allowed for security reasons.
-    # Additionally, it drops all capabilities, which is a common security practice to minimize potential risks.
-    # GitHub issue: https://github.com/fluent/fluent-bit/issues/872#issuecomment-827763207, https://github.com/kyma-project/kyma/pull/11657/files
-    logging:
-      fluentbit:
-        enabled: true
-        image:
-          name: "common-fluentbit"
-          registry: ""
-          repo: ""
-          tag: 4.2.2
-          pullPolicy: IfNotPresent
-        resources:
-          requests:
-            cpu: 50m
-            memory: 100Mi
-          limits:
-            cpu: 100m
-            memory: 150Mi

--- a/charts/tibco-cp-base/charts/router-operator/Chart.yaml
+++ b/charts/tibco-cp-base/charts/router-operator/Chart.yaml
@@ -7,5 +7,5 @@
 
 apiVersion: v2
 name: router-operator
-version: 1.15.0
-appVersion: "1.15.0"
+version: 1.16.0
+appVersion: "1.16.0"

--- a/charts/tibco-cp-base/charts/router-operator/templates/deployment.yaml
+++ b/charts/tibco-cp-base/charts/router-operator/templates/deployment.yaml
@@ -104,7 +104,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["/bin/bash", "-c", "sleep 60"]  # allow some time to complete in-flight API calls and to have new NLB targets become healthy
+              command: ["/busybox/sleep", "60"]  # allow some time to complete in-flight API calls and to have new NLB targets become healthy
         env:
         - name: REAL_IP_TRUSTED_CIDRS # needed for Real-IP calculations
           value: "{{ .Values.global.external.clusterInfo.nodeCIDR }},{{ .Values.global.external.clusterInfo.podCIDR }}"
@@ -150,8 +150,8 @@ spec:
 {{- end }}
 {{- if .Values.global.tibco.logging.fluentbit.enabled }}
       - name: fluentbit
-        image: {{ include "router-operator.image.registry" .}}{{"/"}}{{ include "router-operator.image.repository" .}}{{"/"}}{{ .Values.global.tibco.logging.fluentbit.image.name }}:{{ .Values.global.tibco.logging.fluentbit.image.tag }}
-        imagePullPolicy: {{ .Values.global.tibco.logging.fluentbit.image.pullPolicy }}
+        image: {{ include "router-operator.image.registry" .}}{{"/"}}{{ include "router-operator.image.repository" .}}{{"/common-fluentbit"}}:{{ .Values.global.tibco.commonImages.fluentbit.tag }}
+        imagePullPolicy: IfNotPresent
         {{- if .Values.securityContext }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}

--- a/charts/tibco-cp-base/charts/router-operator/values.yaml
+++ b/charts/tibco-cp-base/charts/router-operator/values.yaml
@@ -32,7 +32,7 @@ additionalLabels: {}
 
 image:
   name: infra-router
-  tag: 816-distroless
+  tag: 821-distroless
   pullPolicy: IfNotPresent
 
 ports:
@@ -121,7 +121,7 @@ ingress:
 
 # Gateway API HTTPRoute configuration (gateway.networking.k8s.io/v1)
 # This provides native Gateway API support for NGINX Gateway Fabric and other Gateway API implementations
-#
+# 
 # IMPORTANT: Gateway API CRDs must be installed in the cluster before enabling this feature
 # Install with: kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/standard-install.yaml
 #
@@ -202,28 +202,6 @@ global:
     # control plane instance Id. Ex: prod, stag, p01, s01. This is to identify multiple cp installation in same cluster.
     # lowercase alphanumeric string of max 5 chars
     controlPlaneInstanceId: ""
-
-    # The fluentbit configuration section.
-    # It specifies that the fluentbit should not run as a non-root user and the user ID should be 0 (root).
-    # Privilege escalation is not allowed for security reasons.
-    # Additionally, it drops all capabilities, which is a common security practice to minimize potential risks.
-    # GitHub issue: https://github.com/fluent/fluent-bit/issues/872#issuecomment-827763207, https://github.com/kyma-project/kyma/pull/11657/files
-    logging:
-      fluentbit:
-        enabled: true
-        image:
-          name: "common-fluentbit"
-          registry: ""
-          repo: ""
-          tag: 4.2.2
-          pullPolicy: IfNotPresent
-        resources:
-          requests:
-            cpu: 50m
-            memory: 100Mi
-          limits:
-            cpu: 100m
-            memory: 150Mi
 
   external:
     clusterInfo:

--- a/charts/tibco-cp-base/charts/tp-cp-alertmanager/Chart.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-alertmanager/Chart.yaml
@@ -17,8 +17,8 @@ apiVersion: v2
 name: tp-cp-alertmanager
 description: The Alertmanager handles alerts sent by client applications such as the Prometheus server.
 type: application
-version: 1.15.0
-appVersion: 1.15.0
+version: 1.16.0
+appVersion: 1.16.0
 kubeVersion: ">=1.19.0-0"
 keywords:
   - monitoring

--- a/charts/tibco-cp-base/charts/tp-cp-alertmanager/templates/statefulset.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-alertmanager/templates/statefulset.yaml
@@ -106,7 +106,8 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         - name: copy-default-configuration
-          image: {{ include "tp-cp-alertmanager.image.registry" .}}{{"/"}}{{ include "tp-cp-alertmanager.image.repository" .}}{{"/"}}{{ .Values.initContainer.name }}:{{ .Values.initContainer.tag}}
+          image: {{ include "tp-cp-alertmanager.image.registry" .}}{{"/"}}{{ include "tp-cp-alertmanager.image.repository" .}}{{"/common-distroless-base-debian-debug"}}:{{ .Values.global.tibco.commonImages.distrolessDebug.tag }}
+          imagePullPolicy: IfNotPresent
         {{- if .Values.securityContext }}
           securityContext:
           {{- toYaml .Values.initContainerSecurityContext | nindent 12 }}

--- a/charts/tibco-cp-base/charts/tp-cp-alertmanager/values.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-alertmanager/values.yaml
@@ -27,7 +27,7 @@ revisionHistoryLimit: 10
 
 image:
   name: infra-alertmanager
-  tag: v0.31.0
+  tag: v0.31.1
   pullPolicy: IfNotPresent
 
 # Full external URL where alertmanager is reachable, used for backlinks.
@@ -443,7 +443,3 @@ global:
     storage:
       pvcName: "control-plane-pvc"
 
-initContainer:
-  name: common-distroless-base-debian-debug
-  tag: 12.13
-  pullPolicy: IfNotPresent

--- a/charts/tibco-cp-base/charts/tp-cp-auditsafe/Chart.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-auditsafe/Chart.yaml
@@ -6,9 +6,9 @@
 
 
 apiVersion: v2
-version: "1.15.5"
+version: "1.16.0"
 name: tp-cp-auditsafe
-appVersion: "1.15.0"
+appVersion: "1.16.0"
 description: Platform AuditSafe chart
 keywords:
   - "auditsafe"

--- a/charts/tibco-cp-base/charts/tp-cp-auditsafe/templates/deployment.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-auditsafe/templates/deployment.yaml
@@ -218,8 +218,8 @@ spec:
                   key: tasMaxWriteDBPoolSize
 {{- if .Values.global.tibco.logging.fluentbit.enabled }}
         - name: fluentbit
-          image: {{ include "tp-cp-auditsafe-web-server.image.registry" .}}{{"/"}}{{ include "tp-cp-auditsafe-web-server.image.repository" .}}{{"/"}}{{ .Values.global.tibco.logging.fluentbit.image.name }}:{{ .Values.global.tibco.logging.fluentbit.image.tag }}
-          imagePullPolicy: {{ .Values.global.tibco.logging.fluentbit.image.pullPolicy }}
+          image: {{ include "tp-cp-auditsafe-web-server.image.registry" .}}{{"/"}}{{ include "tp-cp-auditsafe-web-server.image.repository" .}}{{"/common-fluentbit"}}:{{ .Values.global.tibco.commonImages.fluentbit.tag }}
+          imagePullPolicy: IfNotPresent
           {{- if .Values.auditsafe.securityContext }}
           securityContext:
             {{- toYaml .Values.auditsafe.securityContext | nindent 12 }}

--- a/charts/tibco-cp-base/charts/tp-cp-auditsafe/values.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-auditsafe/values.yaml
@@ -108,35 +108,6 @@ global:
     enableResourceConstraints: true
     tcta:
       TCTA_DB_CONFIGURATION: provider-cp-database-config
-    # The fluentbit configuration section.
-    # It specifies that the fluentbit should not run as a non-root user and the user ID should be 0 (root).
-    # Privilege escalation is not allowed for security reasons.
-    # Additionally, it drops all capabilities, which is a common security practice to minimize potential risks.
-    # GitHub issue: https://github.com/fluent/fluent-bit/issues/872#issuecomment-827763207, https://github.com/kyma-project/kyma/pull/11657/files
-    logging:
-      fluentbit:
-        enabled: true
-        image:
-          name: "common-fluentbit"
-          registry: ""
-          repo: ""
-          tag: 4.2.2
-          pullPolicy: IfNotPresent
-        securityContext:
-          runAsNonRoot: false
-          runAsUser: 0
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop:
-              - ALL
-        resources:
-          requests:
-            cpu: 50m
-            memory: 100Mi
-          limits:
-            cpu: 100m
-            memory: 150Mi
     region: "global"
     self_hosted_deployment: true
     is_replica_region: false
@@ -182,27 +153,6 @@ global:
       capabilities:
         drop:
           - ALL
-    # The fluentbit configuration section.
-    # It specifies that the fluentbit should not run as a non-root user and the user ID should be 0 (root).
-    # Privilege escalation is not allowed for security reasons.
-    # Additionally, it drops all capabilities, which is a common security practice to minimize potential risks.
-    # GitHub issue: https://github.com/fluent/fluent-bit/issues/872#issuecomment-827763207, https://github.com/kyma-project/kyma/pull/11657/files
-    logging:
-      fluentbit:
-        enabled: true
-        image:
-          name: "common-fluentbit"
-          registry: ""
-          repo: ""
-          tag: 4.2.2
-          pullPolicy: IfNotPresent
-        resources:
-          requests:
-            cpu: 50m
-            memory: 100Mi
-          limits:
-            cpu: 100m
-            memory: 150Mi
 
 # replicaCount: 1  # Commented out - HPA manages replicas dynamically
 

--- a/charts/tibco-cp-base/charts/tp-cp-cli/Chart.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-cli/Chart.yaml
@@ -21,10 +21,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.6.0"
+version: "1.7.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.6.0"
+appVersion: "1.7.0"

--- a/charts/tibco-cp-base/charts/tp-cp-cli/templates/cp-cli-card.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-cli/templates/cp-cli-card.yaml
@@ -29,8 +29,8 @@ spec:
       {{- end }}
       containers:
         - name: post-extractor
-          image: {{ include "cp-cli-utilities.image.registry" .}}{{"/"}}{{ include "cp-cli-utilities.infra.image.repository" .}}{{"/"}}{{ $.Values.debug.image.name }}:{{ $.Values.debug.image.tag }}
-          imagePullPolicy: {{ $.Values.containerImageExtractor.image.pullPolicy }}
+          image: {{ include "cp-cli-utilities.image.registry" .}}{{"/"}}{{ include "cp-cli-utilities.infra.image.repository" .}}{{"/common-distroless-base-debian-debug"}}:{{ $.Values.global.tibco.commonImages.distrolessDebug.tag }}
+          imagePullPolicy: IfNotPresent
           {{- with $.Values.probes.startupProbe }}
           startupProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/tibco-cp-base/charts/tp-cp-cli/values.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-cli/values.yaml
@@ -10,11 +10,6 @@ capability:
 source:
   directory: /app
 
-debug:
-  image:
-    name: common-distroless-base-debian-debug
-    tag: 12.13
-
 cpCliCard: true
 scripts:
   resources:

--- a/charts/tibco-cp-base/charts/tp-cp-configuration/Chart.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-configuration/Chart.yaml
@@ -9,8 +9,8 @@ apiVersion: v2
 name: tp-cp-configuration
 description: TIBCO Platform Control Plane Configuration chart
 type: application
-version: 1.15.3
-appVersion: "1.15.0"
+version: 1.16.1
+appVersion: "1.16.0"
 keywords:
   - tibco-platform
   - control-plane

--- a/charts/tibco-cp-base/charts/tp-cp-configuration/files/tp-cp-data-plane/templates/tibcotunnelroute.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-configuration/files/tp-cp-data-plane/templates/tibcotunnelroute.yaml
@@ -38,7 +38,7 @@ spec:
     app.kubernetes.io/name: {{ include "tp-cp-data-plane.consts.subscriptionAppName" .}}
     platform.tibco.com/subscriptionId: {{ .Values.subscriptionId | quote }}
   endpoint:
-    path: {{ if .Values.pathPrefix }}{{ .Values.pathPrefix }}{{ end }}{{ if hasPrefix "/" (tpl .Values.path .) }}{{else}}/{{end}}{{ tpl .Values.path . }}
+    path: {{ if .Values.pathPrefix }}{{ .Values.pathPrefix }}{{ end }}{{ if hasPrefix "/" (tpl .Values.path .) }}{{else}}/{{end}}{{ tpl .Values.path . }}                 
     fqdn: {{ .Values.fqdn }}
     config: accesskey
     configVariables:

--- a/charts/tibco-cp-base/charts/tp-cp-configuration/files/tp-cp-subscription/Chart.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-configuration/files/tp-cp-subscription/Chart.yaml
@@ -9,5 +9,5 @@ apiVersion: v2
 name: tp-cp-subscription
 description: A Helm chart for provision subscription on TIBCO Platform Control Plane
 type: application
-version: 1.15.0
-appVersion: "1.15.0"
+version: 1.16.0
+appVersion: "1.16.0"

--- a/charts/tibco-cp-base/charts/tp-cp-configuration/files/tp-cp-subscription/templates/deployment.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-configuration/files/tp-cp-subscription/templates/deployment.yaml
@@ -92,8 +92,8 @@ spec:
               mountPath: /tmp/logs
 {{- if .Values.global.tibco.logging.fluentbit.enabled }}
         - name: fluentbit
-          image: {{ include "tp-cp-subscription.image.registry" .}}{{"/"}}{{ include "tp-cp-subscription.image.repository" .}}{{"/"}}{{ .Values.global.tibco.logging.fluentbit.image.name }}:{{ .Values.global.tibco.logging.fluentbit.image.tag }}
-          imagePullPolicy: {{ .Values.global.tibco.logging.fluentbit.image.pullPolicy }}
+          image: {{ include "tp-cp-subscription.image.registry" .}}{{"/"}}{{ include "tp-cp-subscription.image.repository" .}}{{"/common-fluentbit"}}:{{ .Values.global.tibco.commonImages.fluentbit.tag }}
+          imagePullPolicy: IfNotPresent
           {{- if .Values.securityContext }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/tibco-cp-base/charts/tp-cp-configuration/files/tp-cp-subscription/values.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-configuration/files/tp-cp-subscription/values.yaml
@@ -14,7 +14,7 @@ subscriptionId: ""
 
 image:
   name: infra-hybrid-server
-  tag: 145-distroless
+  tag: 150-distroless
   pullPolicy: IfNotPresent
 
 # no of replicas
@@ -84,10 +84,6 @@ global:
     logging:
       fluentbit:
         enabled: true
-        image:
-          name: "common-fluentbit"
-          tag: 4.2.2
-          pullPolicy: IfNotPresent
         resources:
           requests:
             cpu: 50m
@@ -95,7 +91,11 @@ global:
           limits:
             cpu: 100m
             memory: 150Mi
-        
+
+    commonImages:
+      fluentbit:
+        tag: "latest"
+      
     useSingleNamespace: false
     enableResourceConstraints: true
   

--- a/charts/tibco-cp-base/charts/tp-cp-configuration/templates/cpproxy.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-configuration/templates/cpproxy.yaml
@@ -15,7 +15,7 @@ metadata:
 data:
   version.json: |
     {
-      "capabilityVersion": "1.15.0",
+      "capabilityVersion": "1.16.0",
       "minCPVersion": "1.1.0",
       "maxCPVersion": "",
       "releaseDate": {{ .Values.capabilities.cpproxy.releaseDate | quote }},
@@ -55,8 +55,12 @@ data:
               host: ${HELM_REPO}
           values:
             - content: |
-                image:
-                  tag: {{ .Values.capabilities.cpproxy.tag | quote }}
+                global:
+                  cp:
+                    logging:
+                      fluentbit:
+                        image:
+                          tag: {{ .Values.global.tibco.commonImages.fluentbit.tag | quote }}
           flags:
             install: true
             createNamespace: false
@@ -86,8 +90,8 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: cp-proxy
-        image: {{ include "tp-cp-configuration.image.registry" .}}{{"/"}}{{ include "tp-cp-configuration.image.repository" .}}{{"/"}}{{ .Values.image.name }}:{{ .Values.image.tag}}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: {{ include "tp-cp-configuration.image.registry" .}}{{"/"}}{{ include "tp-cp-configuration.image.repository" .}}{{"/common-distroless-base-debian-debug"}}:{{ .Values.global.tibco.commonImages.distrolessDebug.tag }}
+        imagePullPolicy: IfNotPresent
         {{- if .Values.securityContext }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
@@ -106,7 +110,7 @@ spec:
         - name: RECIPE_TARGET_LOCATION
           value: "/private/tsc/config/capabilities/infra"
         - name: RECIPE_RELEASE_VERSION
-          value: "1.15.0"
+          value: "1.16.0"
         - name: SPACE_SEPARATED_UNSUPPORTED_RECIPE_VERSIONS
           value: ""
         - name: OVERWRITE_RECIPE

--- a/charts/tibco-cp-base/charts/tp-cp-configuration/templates/integrationcore.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-configuration/templates/integrationcore.yaml
@@ -15,7 +15,7 @@ metadata:
 data:
   version.json: |
     {
-      "capabilityVersion": "1.15.0",
+      "capabilityVersion": "1.16.0",
       "minCPVersion": "1.1.0",
       "maxCPVersion": "",
       "releaseDate": {{ .Values.capabilities.integrationcore.releaseDate | quote }},
@@ -102,8 +102,8 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: integrationcore
-        image: {{ include "tp-cp-configuration.image.registry" .}}{{"/"}}{{ include "tp-cp-configuration.image.repository" .}}{{"/"}}{{ .Values.image.name }}:{{ .Values.image.tag}}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: {{ include "tp-cp-configuration.image.registry" .}}{{"/"}}{{ include "tp-cp-configuration.image.repository" .}}{{"/common-distroless-base-debian-debug"}}:{{ .Values.global.tibco.commonImages.distrolessDebug.tag }}
+        imagePullPolicy: IfNotPresent
         {{- if .Values.securityContext }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
@@ -122,7 +122,7 @@ spec:
         - name: RECIPE_TARGET_LOCATION
           value: "/private/tsc/config/capabilities/infra"
         - name: RECIPE_RELEASE_VERSION
-          value: "1.15.0"
+          value: "1.16.0"
         - name: SPACE_SEPARATED_UNSUPPORTED_RECIPE_VERSIONS
           value: ""
         - name: OVERWRITE_RECIPE

--- a/charts/tibco-cp-base/charts/tp-cp-configuration/templates/license-file.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-configuration/templates/license-file.yaml
@@ -87,8 +87,8 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: dp-license-file
-        image: {{ include "tp-cp-configuration.image.registry" .}}{{"/"}}{{ include "tp-cp-configuration.image.repository" .}}{{"/"}}{{ .Values.image.name }}:{{ .Values.image.tag}}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: {{ include "tp-cp-configuration.image.registry" .}}{{"/"}}{{ include "tp-cp-configuration.image.repository" .}}{{"/common-distroless-base-debian-debug"}}:{{ .Values.global.tibco.commonImages.distrolessDebug.tag }}
+        imagePullPolicy: IfNotPresent
         {{- if .Values.securityContext }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}

--- a/charts/tibco-cp-base/charts/tp-cp-configuration/templates/resource-set-templates.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-configuration/templates/resource-set-templates.yaml
@@ -25,6 +25,8 @@ spec:
       value: {{ include "tp-cp-configuration.image.repository" .}}
     - name: global.tibco.logging.fluentbit.enabled
       value: {{ include "tp-cp-configuration.cp-logging-fluentbit-enabled" . | quote }}
+    - name: global.tibco.commonImages.fluentbit.tag
+      value: {{ .Values.global.tibco.commonImages.fluentbit.tag | quote }}
     {{- if (include "tp-cp-configuration.container-registry.secret" .) }}
     - name: global.tibco.containerRegistry.secret
       value: {{ include "tp-cp-configuration.container-registry.secret" . }}

--- a/charts/tibco-cp-base/charts/tp-cp-configuration/templates/tibcoclusterenvs.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-configuration/templates/tibcoclusterenvs.yaml
@@ -55,4 +55,17 @@ spec:
   group: "infra.router"
   setting: "SUPPORTED_DOMAINS_REGEX"
   value: {{ if eq (.Values.global.tibco.region | default "global") "global" }}""{{ else }}"[^.]+\\.([^.]+\\.{{ include "tp-cp-configuration.cookie-domain" . | replace "." "\\\\." }})"{{ end }}
-  
+
+---
+
+kind: TibcoClusterEnv
+apiVersion: cloud.tibco.com/v1
+metadata:
+  name: "infra.router.cookie.timeout.in.seconds"
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+    {{- include "tp-cp-configuration.labels" $ | nindent 4 }}
+spec:
+  group: "infra.router"
+  setting: "COOKIE_TIMEOUT_IN_SECONDS"
+  value: {{ .Values.global.tibco.idleSessionTimeoutInSeconds | quote }}

--- a/charts/tibco-cp-base/charts/tp-cp-configuration/values.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-configuration/values.yaml
@@ -14,9 +14,6 @@ global:
     storage:
       pvcName: "control-plane-pvc"
   tibco:
-    logging:
-      fluentbit:
-        enabled: true
     # k8s rbac required by the service account
     containerRegistry:
       url: ""
@@ -41,12 +38,6 @@ router:
   # e.g. For domains abc.example1.com and xyz.example2.com, the value should be set as ".example1.com, .example2.com"
   # If not set, the default will be the top level domain of the dnsDomain e.g. for dnsDomain acme.abc.example.com, the value will be ".example.com"
   # validDomains: ""
-
-fluentbit:
-  image:
-    name: "common-fluentbit"
-    tag: 4.2.2
-    pullPolicy: IfNotPresent
 
 # Pod Security Context configuration
 # This configuration ensures that the pod is run with non-root privileges for enhanced security.
@@ -78,8 +69,7 @@ capabilities:
     # set to true for latest version of recipe
     isLatest: "true"
     # Helm chart version for cp proxy, default is latest
-    version: "1.15.5"
-    tag: "300"
+    version: "1.16.3"
     # Timestamp of capability release
     releaseDate: "2025/10/09"
     # Either a link to document or the document itself specifying _what was fixed in this release.
@@ -95,8 +85,8 @@ capabilities:
     releaseNotes: "Enhancements, Bug fixes, etc."
     # helm chart and image version for artifact manager, default helm chart version is latest
     artifactmanager:
-      version: "1.15.2"
-      tag: "147"
+      version: "1.16.0"
+      tag: "149"
   licensefile:
     version: "1.13.0"
     tag: "1"    
@@ -108,12 +98,6 @@ capabilities:
     releaseDate: "2025/11/05"
     # Either a link to document or the document itself specifying _what was fixed in this release.
     releaseNotes: "Initial release."
-# tp-cp-recipes image
-image:
-  name: common-distroless-base-debian-debug
-  tag: 12.13
-  pullPolicy: IfNotPresent
-
 # Resources
 # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 resources:

--- a/charts/tibco-cp-base/charts/tp-cp-core-finops/Chart.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core-finops/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 1.15.0
+appVersion: 1.16.0
 dependencies:
 - name: monitoring-service
-  version: 1.15.489
+  version: 1.16.*
 description: A Helm chart for -- tp-cp-core-finops
 name: tp-cp-core-finops
-version: 1.15.620
+version: 1.16.2

--- a/charts/tibco-cp-base/charts/tp-cp-core-finops/charts/monitoring-service/Chart.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core-finops/charts/monitoring-service/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.15.0
+appVersion: 1.16.0
 description: A Helm chart for -- Monitoring service
 name: monitoring-service
-version: 1.15.489
+version: 1.16.1

--- a/charts/tibco-cp-base/charts/tp-cp-core-finops/charts/monitoring-service/templates/_generated.tpl
+++ b/charts/tibco-cp-base/charts/tp-cp-core-finops/charts/monitoring-service/templates/_generated.tpl
@@ -1,2 +1,2 @@
-{{- define "monitoring-service.generated.buildNumber" }}678{{end -}}
+{{- define "monitoring-service.generated.buildNumber" }}707{{end -}}
 {{- define "monitoring-service.generated.buildTimestamp" }}31-07-25_06.30.00_AM{{end -}}

--- a/charts/tibco-cp-base/charts/tp-cp-core-finops/charts/monitoring-service/templates/monitoring-service-sts.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core-finops/charts/monitoring-service/templates/monitoring-service-sts.yaml
@@ -307,7 +307,8 @@ spec:
 {{- end }}
 {{- if (include "cp-core-configuration.enableLogging" .) }}
       - name: fluentbit
-        image: {{ include "monitoring-service.image.registry" .}}{{"/"}}{{ include "monitoring-service.image.repository" .}}{{"/"}}{{ .Values.global.tibco.logging.fluentbit.image.name }}:{{ .Values.global.tibco.logging.fluentbit.image.tag }}
+        image: {{ include "monitoring-service.image.registry" .}}{{"/"}}{{ include "monitoring-service.image.repository" .}}{{"/common-fluentbit"}}:{{ .Values.global.tibco.commonImages.fluentbit.tag }}
+        imagePullPolicy: IfNotPresent
         {{- if .Values.global.containerSecurityContext.monitoringService }}
         securityContext:
           {{- toYaml .Values.global.containerSecurityContext.monitoringService | nindent 10 }}

--- a/charts/tibco-cp-base/charts/tp-cp-core-finops/charts/monitoring-service/values.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core-finops/charts/monitoring-service/values.yaml
@@ -11,11 +11,6 @@ global:
   tibco:
     db_ssl_root_cert_secretname: "db-ssl-root-cert"
     db_ssl_root_cert_filename: "db_ssl_root.cert"
-    logging:
-      fluentbit:
-        image:
-          name: "common-fluentbit"
-          tag: 4.2.2
   # Pod Security Context configuration
   # This configuration ensures that the pod is run with non-root privileges for enhanced security.
   # The user, group, and filesystem group IDs are all set to 1000.

--- a/charts/tibco-cp-base/charts/tp-cp-core-finops/templates/monitor-agent.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core-finops/templates/monitor-agent.yaml
@@ -15,7 +15,7 @@ metadata:
 data:
   version.json: |
     {
-      "capabilityVersion": "1.15.0",
+      "capabilityVersion": "1.16.0",
       "minCPVersion": "1.1.0",
       "maxCPVersion": "",
       "releaseDate": {{ .Values.capabilities.monitorAgent.releaseDate | quote }},
@@ -87,8 +87,8 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: monitor-agent
-        image: {{ include "tp-cp-monitor-agent.image.registry" .}}{{"/"}}{{ include "tp-cp-monitor-agent.image.repository" .}}{{"/"}}{{ .Values.image.name }}:{{ .Values.image.tag}}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: {{ include "tp-cp-monitor-agent.image.registry" .}}{{"/"}}{{ include "tp-cp-monitor-agent.image.repository" .}}{{"/common-distroless-base-debian-debug"}}:{{ .Values.global.tibco.commonImages.distrolessDebug.tag }}
+        imagePullPolicy: IfNotPresent
         {{- if .Values.securityContext }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
@@ -107,7 +107,7 @@ spec:
         - name: RECIPE_TARGET_LOCATION
           value: "/private/tsc/config/capabilities/infra"
         - name: RECIPE_RELEASE_VERSION
-          value: "1.15.0"
+          value: "1.16.0"
         - name: SPACE_SEPARATED_UNSUPPORTED_RECIPE_VERSIONS
           value: ""
         - name: OVERWRITE_RECIPE

--- a/charts/tibco-cp-base/charts/tp-cp-core-finops/values.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core-finops/values.yaml
@@ -25,9 +25,6 @@ global:
       password: ""
       repository: "tibco-platform-docker-prod"  # repository
     controlPlaneInstanceId: ""
-    logging:
-      fluentbit:
-        enabled: true
   # Pod Security Context configuration
   # This configuration ensures that the pod is run with non-root privileges for enhanced security.
   # The user, group, and filesystem group IDs are all set to 1000.
@@ -80,8 +77,8 @@ capabilities:
     # set to true for latest version of recipe
     isLatest: "true"
     # Helm chart version for monitor-agent, default is latest
-    version: "1.15.228"
-    tag: "380"
+    version: "1.16.230"
+    tag: "381"
     # Timestamp of capability release
     releaseDate: "2024/07/22"
     # Either a link to document or the document itself specifying _what was fixed in this release.
@@ -94,11 +91,6 @@ podRecipeSecurityContext:
   fsGroupChangePolicy: "Always"
   seccompProfile:
     type: RuntimeDefault
-
-image:
-  name: common-distroless-base-debian-debug
-  tag: 12.13
-  pullPolicy: IfNotPresent
 
 securityContext:
   # It specifies that privilege escalation is not allowed for security reasons.

--- a/charts/tibco-cp-base/charts/tp-cp-core/Chart.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core/Chart.yaml
@@ -1,27 +1,27 @@
 apiVersion: v2
-appVersion: 1.15.0
+appVersion: 1.16.0
 dependencies:
 - condition: web-server.enabled
   name: web-server
-  version: 1.15.*
+  version: 1.16.*
 - condition: orchestrator.enabled
   name: orchestrator
-  version: 1.15.*
+  version: 1.16.*
 - condition: user-subscriptions.enabled
   name: user-subscriptions
-  version: 1.15.*
+  version: 1.16.*
 - condition: cronjobs.enabled
   name: cronjobs
-  version: 1.15.*
+  version: 1.16.*
 - condition: identity-management.enabled
   name: identity-management
-  version: 1.15.*
+  version: 1.16.*
 - condition: identity-provider.enabled
   name: identity-provider
-  version: 1.15.*
+  version: 1.16.*
 - condition: pengine.enabled
   name: pengine
-  version: 1.15.*
+  version: 1.16.*
 description: A Helm chart for -- tp-cp-core
 name: tp-cp-core
-version: 1.15.11
+version: 1.16.0

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/cronjobs/Chart.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/cronjobs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.15.0
+appVersion: 1.16.0
 description: A Helm chart for -- Cron Jobs
 name: cronjobs
-version: 1.15.0
+version: 1.16.0

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/cronjobs/templates/_generated.tpl
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/cronjobs/templates/_generated.tpl
@@ -1,2 +1,2 @@
-{{- define "cronjobs.generated.buildNumber" }}770{{end -}}
+{{- define "cronjobs.generated.buildNumber" }}776{{end -}}
 {{- define "cronjobs.generated.buildTimestamp" }}02-11-26_01.01.49_PM{{end -}}

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/cronjobs/templates/cp-cronjobs.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/cronjobs/templates/cp-cronjobs.yaml
@@ -78,7 +78,7 @@ spec:
       terminationGracePeriodSeconds: 15
       initContainers:
       - name: check-pod-dependencies
-        image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/"}}{{ .Values.global.tibco.check_dependencies.distroless_debian.name }}:{{ .Values.global.tibco.check_dependencies.distroless_debian.tag }}
+        image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/common-distroless-base-debian-debug"}}:{{ .Values.global.tibco.commonImages.distrolessDebug.tag }}
         {{- if .Values.global.containerSecurityContext }}
         resources:
           {{- toYaml .Values.checkPodDependencies.resources | nindent 10 }}
@@ -93,7 +93,7 @@ spec:
                 name: {{ include "tp-control-plane-dnsdomain-configmap" . }}
                 key: TP_CP_IDM_HOST
       - name: check-sql-schema-version
-        image: '{{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}/core-cp-scripts:{{ include "cp-core-scripts.buildNumber" . }}'
+        image: '{{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}/core-cp-scripts:{{ .Values.global.tibco.commonImages.cpScripts.tag }}'
         {{- if .Values.global.containerSecurityContext }}
         securityContext:
           {{- toYaml .Values.global.containerSecurityContext | nindent 10 }}
@@ -319,7 +319,7 @@ spec:
             mountPath: /tmp/logs
 {{- if (include "cp-core-configuration.enableLogging" .) }}
       - name: fluentbit
-        image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/"}}{{ .Values.global.tibco.logging.fluentbit.image.name }}:{{ .Values.global.tibco.logging.fluentbit.image.tag }}
+        image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/common-fluentbit"}}:{{ .Values.global.tibco.commonImages.fluentbit.tag }}
         {{- if .Values.global.containerSecurityContext }}
         securityContext:
           {{- toYaml .Values.global.containerSecurityContext | nindent 10 }}

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/cronjobs/values.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/cronjobs/values.yaml
@@ -14,15 +14,6 @@ global:
     db_ssl_root_cert_filename: "db_ssl_root.cert"
     hybridConnectivity:
       enabled: true
-    logging:
-      fluentbit:
-        image:
-          name: "common-fluentbit"
-          tag: 4.2.2
-    check_dependencies:
-      distroless_debian:
-        name: "common-distroless-base-debian-debug"
-        tag: 12.13
     cronjobs:
       disableProvisionInfraCapabilitiesJob: "false"
       disableGdprPurgeHistoryJob: "true"

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/identity-management/Chart.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/identity-management/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.15.0
+appVersion: 1.16.0
 description: A Helm Chart for TIBCO Platform Control Plane -- Identity Management
 name: identity-management
-version: 1.15.0
+version: 1.16.0

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/identity-management/templates/_generated.tpl
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/identity-management/templates/_generated.tpl
@@ -1,2 +1,2 @@
-{{- define "identity-management.generated.buildNumber" }}3172{{end -}}
-{{- define "identity-management.generated.buildTimestamp" }}02-13-26_3.30.00_PM{{end -}}
+{{- define "identity-management.generated.buildNumber" }}3246{{end -}}
+{{- define "identity-management.generated.buildTimestamp" }}03-10-26_11.00.00_AM{{end -}}

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/identity-management/templates/idm.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/identity-management/templates/idm.yaml
@@ -80,7 +80,7 @@ spec:
       terminationGracePeriodSeconds: 15
       initContainers:
       - name: check-pod-dependencies
-        image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/"}}{{ .Values.global.tibco.check_dependencies.distroless_debian.name }}:{{ .Values.global.tibco.check_dependencies.distroless_debian.tag }}
+        image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/common-distroless-base-debian-debug"}}:{{ .Values.global.tibco.commonImages.distrolessDebug.tag }}
         {{- if .Values.global.containerSecurityContext }}
         resources:
           {{- toYaml .Values.checkPodDependencies.resources | nindent 10 }}
@@ -96,7 +96,7 @@ spec:
                 name: {{ include "tp-control-plane-dnsdomain-configmap" . }}
                 key: TP_CP_ORCH_HOST
       - name: check-sql-schema-version
-        image: '{{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}/core-cp-scripts:{{ include "cp-core-scripts.buildNumber" . }}'
+        image: '{{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}/core-cp-scripts:{{ .Values.global.tibco.commonImages.cpScripts.tag }}'
         {{- if .Values.global.containerSecurityContext }}
         securityContext:
           {{- toYaml .Values.global.containerSecurityContext | nindent 10 }}
@@ -419,7 +419,7 @@ spec:
           mountPath: /tmp/files
 {{- if (include "cp-core-configuration.enableLogging" .) }}
       - name: fluentbit
-        image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/"}}{{ .Values.global.tibco.logging.fluentbit.image.name }}:{{ .Values.global.tibco.logging.fluentbit.image.tag }}
+        image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/common-fluentbit"}}:{{ .Values.global.tibco.commonImages.fluentbit.tag }}
         {{- if .Values.global.containerSecurityContext }}
         securityContext:
           {{- toYaml .Values.global.containerSecurityContext | nindent 10 }}
@@ -1238,6 +1238,16 @@ spec:
     - listener: intercom
       config: empty
       fqdn: ""
+      methods:
+      - POST
+  - path: /idm/v1/parse-license
+    internalPath: /v1/parse-license
+    port: 7831
+    protocol: http
+    proxies:
+    - listener: virtual
+      config: secure
+      fqdn: ${TSC_DNS_DOMAIN}
       methods:
       - POST
   directAccessEndpoints:

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/identity-management/values.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/identity-management/values.yaml
@@ -14,15 +14,6 @@ global:
     image_name:
       identityManagement: ""
     image_repo_path: ""
-    logging:
-      fluentbit:
-        image:
-          name: "common-fluentbit"
-          tag: 4.2.2
-    check_dependencies:
-      distroless_debian:
-        name: "common-distroless-base-debian-debug"
-        tag: 12.13
   external:
     region: ""
     enableLogging: false

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/identity-provider/Chart.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/identity-provider/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.15.0
+appVersion: 1.16.0
 description: A Helm Chart for TIBCO Platform Control Plane -- Identity Provider
 name: identity-provider
-version: 1.15.0
+version: 1.16.0

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/identity-provider/templates/_generated.tpl
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/identity-provider/templates/_generated.tpl
@@ -1,2 +1,2 @@
-{{- define "identity-provider.generated.buildNumber" }}1038{{end -}}
-{{- define "identity-provider.generated.buildTimestamp" }}02-11-26_05.45.00_PM{{end -}}
+{{- define "identity-provider.generated.buildNumber" }}1068{{end -}}
+{{- define "identity-provider.generated.buildTimestamp" }}03-12-26_11.00.00_AM{{end -}}

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/identity-provider/templates/cp-identity-provider.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/identity-provider/templates/cp-identity-provider.yaml
@@ -71,7 +71,7 @@ spec:
       terminationGracePeriodSeconds: 15
       initContainers:
       - name: check-pod-dependencies
-        image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/"}}{{ .Values.global.tibco.check_dependencies.distroless_debian.name }}:{{ .Values.global.tibco.check_dependencies.distroless_debian.tag }}
+        image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/common-distroless-base-debian-debug"}}:{{ .Values.global.tibco.commonImages.distrolessDebug.tag }}
         {{- if .Values.global.containerSecurityContext }}
         resources:
           {{- toYaml .Values.checkPodDependencies.resources | nindent 10 }}
@@ -86,7 +86,7 @@ spec:
                 name: {{ include "tp-control-plane-dnsdomain-configmap" . }}
                 key: TP_CP_IDM_HOST
       - name: check-sql-schema-version
-        image: '{{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}/core-cp-scripts:{{ include "cp-core-scripts.buildNumber" . }}'
+        image: '{{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}/core-cp-scripts:{{ .Values.global.tibco.commonImages.cpScripts.tag }}'
         {{- if .Values.global.containerSecurityContext }}
         securityContext:
           {{- toYaml .Values.global.containerSecurityContext | nindent 10 }}
@@ -244,7 +244,7 @@ spec:
           readOnly: true
 {{- if (include "cp-core-configuration.enableLogging" .)}}
       - name: fluentbit
-        image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/"}}{{ .Values.global.tibco.logging.fluentbit.image.name }}:{{ .Values.global.tibco.logging.fluentbit.image.tag }}
+        image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/common-fluentbit"}}:{{ .Values.global.tibco.commonImages.fluentbit.tag }}
         {{- if .Values.global.containerSecurityContext }}
         securityContext:
           {{- toYaml .Values.global.containerSecurityContext | nindent 10 }}

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/identity-provider/values.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/identity-provider/values.yaml
@@ -11,15 +11,6 @@ global:
     image_repo_path: ""
     db_ssl_root_cert_secretname: "db-ssl-root-cert"
     db_ssl_root_cert_filename: "db_ssl_root.cert"
-    logging:
-      fluentbit:
-        image:
-          name: "common-fluentbit"
-          tag: 4.2.2
-    check_dependencies:
-      distroless_debian:
-        name: "common-distroless-base-debian-debug"
-        tag: 12.13
   external:
     enableLogging: false
     region: ""

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/orchestrator/Chart.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/orchestrator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.15.0
+appVersion: 1.16.0
 description: A Helm chart for -- Orchestrator
 name: orchestrator
-version: 1.15.0
+version: 1.16.0

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/orchestrator/templates/_generated.tpl
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/orchestrator/templates/_generated.tpl
@@ -1,2 +1,2 @@
-{{- define "orchestrator.generated.buildNumber" }}6693{{end -}}
-{{- define "orchestrator.generated.buildTimestamp" }}02-19-26_02.00.00_PM{{end -}}
+{{- define "orchestrator.generated.buildNumber" }}6804{{end -}}
+{{- define "orchestrator.generated.buildTimestamp" }}03-09-26_06.30.00_PM{{end -}}

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/orchestrator/templates/cp-orch.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/orchestrator/templates/cp-orch.yaml
@@ -113,7 +113,7 @@ spec:
       terminationGracePeriodSeconds: 15
       initContainers:
       - name: check-pod-dependencies
-        image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/"}}{{ .Values.global.tibco.check_dependencies.distroless_debian.name }}:{{ .Values.global.tibco.check_dependencies.distroless_debian.tag }}
+        image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/common-distroless-base-debian-debug"}}:{{ .Values.global.tibco.commonImages.distrolessDebug.tag }}
         {{- if .Values.global.containerSecurityContext }}
         resources:
           {{- toYaml .Values.checkPodDependencies.resources | nindent 10 }}
@@ -134,7 +134,7 @@ spec:
                 name: {{ include "tp-control-plane-dnsdomain-configmap" . }}
                 key: TP_CP_EMAIL_SERVICE_HOST
       - name: check-sql-schema-version
-        image: '{{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}/core-cp-scripts:{{ include "cp-core-scripts.buildNumber" . }}'
+        image: '{{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}/core-cp-scripts:{{ .Values.global.tibco.commonImages.cpScripts.tag }}'
         {{- if .Values.global.containerSecurityContext }}
         securityContext:
           {{- toYaml .Values.global.containerSecurityContext | nindent 10 }}
@@ -576,7 +576,7 @@ spec:
             mountPath: /tmp/logs
 {{- if (include "cp-core-configuration.enableLogging" .) }}
       - name: fluentbit
-        image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/"}}{{ .Values.global.tibco.logging.fluentbit.image.name }}:{{ .Values.global.tibco.logging.fluentbit.image.tag }}
+        image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/common-fluentbit"}}:{{ .Values.global.tibco.commonImages.fluentbit.tag }}
         {{- if .Values.global.containerSecurityContext }}
         securityContext:
           {{- toYaml .Values.global.containerSecurityContext | nindent 10 }}

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/orchestrator/values.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/orchestrator/values.yaml
@@ -54,15 +54,6 @@ global:
       password: ""
       pullLatestCharts: false
       certificateSecretName: ""
-    logging:
-      fluentbit:
-        image:
-          name: "common-fluentbit"
-          tag: 4.2.2
-    check_dependencies:
-      distroless_debian:
-        name: "common-distroless-base-debian-debug"
-        tag: 12.13
     self_hosted_deployment: true
       
 

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/pengine/Chart.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/pengine/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.15.0
+appVersion: 1.16.0
 description: A Helm Chart for TIBCO Platform Control Plane Permissions Engine
 name: pengine
-version: 1.15.0
+version: 1.16.0

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/pengine/templates/_generated.tpl
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/pengine/templates/_generated.tpl
@@ -1,2 +1,2 @@
-{{- define "pengine.generated.buildNumber" }}1494{{end -}}
-{{- define "pengine.generated.buildTimestamp" }}02-13-25_03.30.00_PM{{end -}}
+{{- define "pengine.generated.buildNumber" }}1626{{end -}}
+{{- define "pengine.generated.buildTimestamp" }}03-13-25_11.00.00_AM{{end -}}

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/pengine/templates/tp-cp-pengine.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/pengine/templates/tp-cp-pengine.yaml
@@ -93,7 +93,7 @@ spec:
       terminationGracePeriodSeconds: 15
       initContainers:
         - name: check-sql-schema-version
-          image: '{{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}/core-cp-scripts:{{ include "cp-core-scripts.buildNumber" . }}'
+          image: '{{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}/core-cp-scripts:{{ .Values.global.tibco.commonImages.cpScripts.tag }}'
           {{- if .Values.global.containerSecurityContext }}
           securityContext:
             {{- toYaml .Values.global.containerSecurityContext | nindent 12 }}
@@ -285,7 +285,7 @@ spec:
           mountPath: /tmp/logs
 {{- if (include "cp-core-configuration.enableLogging" .) }}
       - name: fluentbit
-        image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/"}}{{ .Values.global.tibco.logging.fluentbit.image.name }}:{{ .Values.global.tibco.logging.fluentbit.image.tag }}
+        image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/common-fluentbit"}}:{{ .Values.global.tibco.commonImages.fluentbit.tag }}
         {{- if .Values.global.containerSecurityContext }}
         securityContext:
           {{- toYaml .Values.global.containerSecurityContext | nindent 10 }}

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/pengine/values.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/pengine/values.yaml
@@ -12,11 +12,6 @@ global:
     db_ssl_root_cert_secretname: "db-ssl-root-cert"
     db_ssl_root_cert_filename: "db_ssl_root.cert"
     is_replica_region: false
-    logging:
-      fluentbit:
-        image:
-          name: "common-fluentbit"
-          tag: 4.2.2
   external:
     enableLogging: false
     region: ""

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/user-subscriptions/Chart.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/user-subscriptions/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.15.0
+appVersion: 1.16.0
 description: A Helm chart for -- User Subscriptions
 name: user-subscriptions
-version: 1.15.0
+version: 1.16.0

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/user-subscriptions/templates/_generated.tpl
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/user-subscriptions/templates/_generated.tpl
@@ -1,2 +1,2 @@
-{{- define "user-subscriptions.generated.buildNumber" }}2885{{end -}}
-{{- define "user-subscriptions.generated.buildTimestamp" }}02-11-26_09.30.00_PM{{end -}}
+{{- define "user-subscriptions.generated.buildNumber" }}2917{{end -}}
+{{- define "user-subscriptions.generated.buildTimestamp" }}03-02-26_04.30.00_PM{{end -}}

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/user-subscriptions/templates/cp-user-sub.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/user-subscriptions/templates/cp-user-sub.yaml
@@ -92,7 +92,8 @@ spec:
       terminationGracePeriodSeconds: 15
       initContainers:
         - name: check-permissions-engine
-          image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/"}}{{ .Values.global.tibco.check_dependencies.distroless_debian.name }}:{{ .Values.global.tibco.check_dependencies.distroless_debian.tag }}
+          image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/common-distroless-base-debian-debug"}}:{{ .Values.global.tibco.commonImages.distrolessDebug.tag }}
+          imagePullPolicy: IfNotPresent
           {{- if .Values.global.containerSecurityContext }}
           resources:
             {{- toYaml .Values.checkPermissionEngine.resources | nindent 12 }}
@@ -109,7 +110,7 @@ spec:
                   key: TP_CP_PERMISSIONS_ENGINE_HOST
                   name: {{ include "tp-control-plane-dnsdomain-configmap" . }}
         - name: check-sql-schema-version
-          image: '{{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}/core-cp-scripts:{{ include "cp-core-scripts.buildNumber" . }}'
+          image: '{{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}/core-cp-scripts:{{ .Values.global.tibco.commonImages.cpScripts.tag }}'
           {{- if .Values.global.containerSecurityContext }}
           securityContext:
             {{- toYaml .Values.global.containerSecurityContext | nindent 12 }}
@@ -330,7 +331,7 @@ spec:
           mountPath: /tmp/logs
 {{- if (include "cp-core-configuration.enableLogging" .) }}
       - name: fluentbit
-        image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/"}}{{ .Values.global.tibco.logging.fluentbit.image.name }}:{{ .Values.global.tibco.logging.fluentbit.image.tag }}
+        image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/common-fluentbit"}}:{{ .Values.global.tibco.commonImages.fluentbit.tag }}
         {{- if .Values.global.containerSecurityContext }}
         securityContext:
           {{- toYaml .Values.global.containerSecurityContext | nindent 10 }}

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/user-subscriptions/values.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/user-subscriptions/values.yaml
@@ -17,15 +17,6 @@ global:
     is_replica_region: false
     db_ssl_root_cert_secretname: "db-ssl-root-cert"
     db_ssl_root_cert_filename: "db_ssl_root.cert"
-    logging:
-      fluentbit:
-        image:
-          name: "common-fluentbit"
-          tag: 4.2.2
-    check_dependencies:
-      distroless_debian:
-        name: "common-distroless-base-debian-debug"
-        tag: 12.13
     cronjobs:
       disableProvisionInfraCapabilitiesJob: "false"
       disableGdprPurgeHistoryJob: "true"

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/web-server/Chart.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/web-server/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.15.0
+appVersion: 1.16.0
 description: A Helm chart for -- WebServer
 name: web-server
-version: 1.15.0
+version: 1.16.0

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/web-server/templates/_consts.tpl
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/web-server/templates/_consts.tpl
@@ -44,7 +44,6 @@
 {{- end }}
 
 {{- define "tp-cp-web-server.consts.http.request.timeout" }}120000{{ end -}}
-{{- define "tp-cp-web-server.consts.idle.time.seconds" }}14400{{ end -}}
 {{- define "tp-cp-web-server.consts.custom.scheme.urls" }}'["vscode://tibco.flogo"]'{{ end -}}
 {{- define "tp-cp-web-server.consts.web.server.log.enabled" }}true{{ end -}}
 {{- define "tp-cp-web-server.consts.external.idp.ui" }}enable{{ end -}}

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/web-server/templates/_generated.tpl
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/web-server/templates/_generated.tpl
@@ -1,2 +1,2 @@
-{{- define "web-server.generated.buildNumber" }}8401{{end -}}
-{{- define "web-server.generated.buildTimestamp" }}02-11-26_09.30.00_AM{{end -}}
+{{- define "web-server.generated.buildNumber" }}8684{{end -}}
+{{- define "web-server.generated.buildTimestamp" }}03-13-26_10.40.00_PM{{end -}}

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/web-server/templates/cp-webserver.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/web-server/templates/cp-webserver.yaml
@@ -109,7 +109,7 @@ spec:
       terminationGracePeriodSeconds: 15
       initContainers:
       - name: check-pod-dependencies
-        image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/"}}{{ .Values.global.tibco.check_dependencies.distroless_debian.name }}:{{ .Values.global.tibco.check_dependencies.distroless_debian.tag }}
+        image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/common-distroless-base-debian-debug"}}:{{ .Values.global.tibco.commonImages.distrolessDebug.tag }}
         {{- if .Values.global.containerSecurityContext }}
         resources:
           {{- toYaml .Values.checkPodDependencies.resources | nindent 10 }}
@@ -285,6 +285,15 @@ spec:
             configMapKeyRef:
               name: {{ include "tp-control-plane-dnsdomain-configmap" . }}
               key: TP_O11Y_MCP_SERVER_HOST
+{{- if .Values.cpwebserver.aiAgent.enabled }}
+        - name: TP_AI_AGENT_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "tp-control-plane-dnsdomain-configmap" . }}
+              key: TP_AI_AGENT_HOST
+        - name: AI_AGENT_CONFIG
+          value: '{"enabled":true,"url":"http://$(TP_AI_AGENT_HOST):8000"}'
+{{- end }}
         - name: SYSTEM_WHO
           value: {{ .Values.global.tibco.controlPlaneInstanceId }}
         - name: SYSTEM_INTERNAL_COMPUTE_SERVICE_HOST
@@ -320,7 +329,7 @@ spec:
         - name: HTTP_REQUEST_TIMEOUT
           value: {{ include "tp-cp-web-server.consts.http.request.timeout" . | quote }}
         - name: IDLE_TIME_SECONDS
-          value: {{ include "tp-cp-web-server.consts.idle.time.seconds" . | quote }}
+          value: {{ .Values.global.tibco.idleSessionTimeoutInSeconds | quote }}
         - name: CUSTOM_SCHEME_URLS
           value: {{ include "tp-cp-web-server.consts.custom.scheme.urls" . }}
         - name: WEB_SERVER_LOG_ENABLED
@@ -442,15 +451,22 @@ spec:
             value: "localhost:3000"
           - name: LOG_LEVEL
             value: {{ .Values.cpmcpserver.logLevel }}
+          - name: READ_ONLY_MODE
+            value: "{{ .Values.cpmcpserver.readOnlyMode }}"
           - name: PORT
             value: "8066"
+          - name: MCP_SERVER_VERSION
+            valueFrom:
+              configMapKeyRef:
+                name: {{ include "tp-control-plane-dnsdomain-configmap" . }}
+                key: TP_CP_APP_VERSION
         volumeMounts:
           - name: logs
             mountPath: /tmp/logs
  {{- end }}
 {{- if (include "cp-core-configuration.enableLogging" .) }}
       - name: fluentbit
-        image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/"}}{{ .Values.global.tibco.logging.fluentbit.image.name }}:{{ .Values.global.tibco.logging.fluentbit.image.tag }}
+        image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/common-fluentbit"}}:{{ .Values.global.tibco.commonImages.fluentbit.tag }}
         {{- if .Values.global.containerSecurityContext }}
         securityContext:
           {{- toYaml .Values.global.containerSecurityContext | nindent 10 }}

--- a/charts/tibco-cp-base/charts/tp-cp-core/charts/web-server/values.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core/charts/web-server/values.yaml
@@ -14,15 +14,6 @@ global:
       webserver: ""
     image_repo_path: ""
     self_hosted_deployment: true
-    logging:
-      fluentbit:
-        image:
-          name: "common-fluentbit"
-          tag: 4.2.2
-    check_dependencies:
-      distroless_debian:
-        name: "common-distroless-base-debian-debug"
-        tag: 12.13
     finops: "disable"
     msg_dp_config_enabled: "true"
 
@@ -54,6 +45,8 @@ global:
 
 # Resource values for production like setup
 cpwebserver:
+  aiAgent:
+    enabled: false
   resources:
     requests:
       cpu: 200m
@@ -92,7 +85,7 @@ cpmcpserver:
   enabled: false
   image:
     name: infra-cp-mcp-server
-    tag: "509-distroless"
+    tag: "562-distroless"
   logLevel: "INFO"
   resources:
     requests:

--- a/charts/tibco-cp-base/charts/tp-cp-core/files/tsc/config-core/emails-templates/tsc/reports_html.tmpl
+++ b/charts/tibco-cp-base/charts/tp-cp-core/files/tsc/config-core/emails-templates/tsc/reports_html.tmpl
@@ -266,7 +266,7 @@
         <p style="margin:0;padding: 8px 0 8px 8px;">If you have any questions about your account or capabilities,
             <br>contact your TIBCO® Platform admin.</p>
         <img style="width: 150px; outline: none; text-decoration: none; display: block;  border-width: 0;padding: 0px 0px 0 200px;margin-top: 0;" src="{{.ImageHostURL}}/csg_logo.png" alt="TIBCO® Software Inc."/>
-        <p style="margin:0;padding: 8px 0 8px 8px; text-align: center">ⓒ 2023-2025 Cloud Software Group, Inc. All rights reserved.</p>
+        <p style="margin:0;padding: 8px 0 8px 8px; text-align: center">ⓒ 2023-2026 Cloud Software Group, Inc. All rights reserved.</p>
     </div>
 
 </div>

--- a/charts/tibco-cp-base/charts/tp-cp-core/files/tsc/config/emails-templates/tsc/reports_html.tmpl
+++ b/charts/tibco-cp-base/charts/tp-cp-core/files/tsc/config/emails-templates/tsc/reports_html.tmpl
@@ -320,7 +320,7 @@
         <p style="margin:0;padding: 8px 0 8px 8px;">If you have any questions about your account or capabilities,
             <br>contact <a href="https://www.tibco.com/contact-us"> TIBCO Support</a>{{if .SalesOrderNumber}} and mention your Sales Order number {{.SalesOrderNumber}}{{end}}.</p>
         <img style="width: 150px; outline: none; text-decoration: none; display: block;  border-width: 0;padding: 0px 0px 0 200px;margin-top: 0;" src="{{.ImageHostURL}}/csg_logo.png" alt="TIBCO® Software Inc."/>
-        <p style="margin:0;padding: 8px 0 8px 8px; text-align: center">ⓒ 2023-2025 Cloud Software Group, Inc. All rights reserved.</p>
+        <p style="margin:0;padding: 8px 0 8px 8px; text-align: center">ⓒ 2023-2026 Cloud Software Group, Inc. All rights reserved.</p>
     </div>
 
 </div>

--- a/charts/tibco-cp-base/charts/tp-cp-core/templates/_consts.tpl
+++ b/charts/tibco-cp-base/charts/tp-cp-core/templates/_consts.tpl
@@ -29,6 +29,7 @@
 {{- define "tpcontrol-plane.consts.tpCpBwMcpServerServiceName" }}tp-cp-bw-mcpserver.{{ include "tp-control-plane.consts.namespace" . }}.svc.cluster.local{{ end -}}
 {{- define "tpcontrol-plane.consts.tpCpFlogoMcpServerServiceName" }}tp-cp-flogo-mcpserver.{{ include "tp-control-plane.consts.namespace" . }}.svc.cluster.local{{ end -}}
 {{- define "tpcontrol-plane.consts.tpO11yMcpServerServiceName" }}tp-o11y-mcp-server.{{ include "tp-control-plane.consts.namespace" . }}.svc.cluster.local{{ end -}}
+{{- define "tpcontrol-plane.consts.tpAiAgentServiceName" }}tp-cp-ai-agent.{{ include "tp-control-plane.consts.namespace" . }}.svc.cluster.local{{ end -}}
 {{- define "tpcontrol-plane.consts.provisionerAgentURLFramework" -}}
     {{- if (include "cp-core-configuration.isSingleNamespace" .) }}
         {{- "dp-%s." }}{{ .Release.Namespace }}{{ ".svc.cluster.local" -}}
@@ -45,7 +46,7 @@
 {{- define "tpcontrol-plane.consts.tpCpFLOGOServiceName" }}tp-cp-flogo-webserver.{{ include "tp-control-plane.consts.namespace" . }}.svc.cluster.local{{ end -}}
 {{- define "tpcontrol-plane.consts.tpCpBEServiceName" }}tp-cp-be-webserver.{{ include "tp-control-plane.consts.namespace" . }}.svc.cluster.local{{ end -}}
 {{- define "tpcontrol-plane.consts.tpCpEMSServiceName" }}msg-webserver.{{ include "tp-control-plane.consts.namespace" . }}.svc.cluster.local{{ end -}}
-{{- define "tpcontrol-plane.consts.docBaseUrl" }}https://docs.tibco.com/go/platform-cp/1.15.0/doc/html{{ end -}}
+{{- define "tpcontrol-plane.consts.docBaseUrl" }}https://docs.tibco.com/go/platform-cp/1.16.0/doc/html{{ end -}}
 
 {{- define "cp-core-configuration.service-account-name" }}
 {{- if empty .Values.global.tibco.serviceAccount -}}

--- a/charts/tibco-cp-base/charts/tp-cp-core/templates/_generated.tpl
+++ b/charts/tibco-cp-base/charts/tp-cp-core/templates/_generated.tpl
@@ -3,6 +3,3 @@
  This file is subject to the license terms contained
  in the license file that is distributed with this file.
 */}}
-
-{{/* CP Core scripts build nnumber */}}
-{{- define "cp-core-scripts.buildNumber" }}9153{{end -}}

--- a/charts/tibco-cp-base/charts/tp-cp-core/templates/create_admin_user.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core/templates/create_admin_user.yaml
@@ -33,7 +33,7 @@ spec:
       restartPolicy: Never
       initContainers:
       - name: check-pod-dependencies
-        image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/"}}{{ .Values.global.tibco.check_dependencies.distroless_debian.name }}:{{ .Values.global.tibco.check_dependencies.distroless_debian.tag }}
+        image: {{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}{{"/common-distroless-base-debian-debug"}}:{{ .Values.global.tibco.commonImages.distrolessDebug.tag }}
       {{- if .Values.global.containerSecurityContextTpcpcoreJob }}
         resources:
         {{- toYaml .Values.checkPodDependencies.resources | nindent 10 }}
@@ -66,7 +66,7 @@ spec:
         securityContext:
           {{- toYaml .Values.global.containerSecurityContextTpcpcoreJob | nindent 10 }}
         {{- end }}        
-        image: '{{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}/core-cp-scripts:{{ include "cp-core-scripts.buildNumber" . }}'
+        image: '{{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}/core-cp-scripts:{{ .Values.global.tibco.commonImages.cpScripts.tag }}'
         imagePullPolicy: IfNotPresent
         env:
         - name: REGION

--- a/charts/tibco-cp-base/charts/tp-cp-core/templates/helpers.tpl
+++ b/charts/tibco-cp-base/charts/tp-cp-core/templates/helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
- Copyright © 2025. Cloud Software Group, Inc.
+ Copyright © 2026 Cloud Software Group, Inc.
  This file is subject to the license terms contained
  in the license file that is distributed with this file.
 */}}
@@ -22,17 +22,6 @@
   {{- end }}
 {{- end -}}
 
-{{/*
-Returns the ServiceAccount name for the cleanup job.
-Uses user-provided serviceAccount if available, otherwise dedicated cleanup-sa.
-*/}}
-{{- define "tp-cp-core.cleanup.serviceAccountName" -}}
-  {{- if empty .Values.global.tibco.serviceAccount }}
-    {{- include "tp-control-plane.consts.appName" . }}-cleanup-sa
-  {{- else }}
-    {{- .Values.global.tibco.serviceAccount }}
-  {{- end }}
-{{- end -}}
 
 {{/*
 Returns the container registry secret name for cleanup jobs.

--- a/charts/tibco-cp-base/charts/tp-cp-core/templates/jobs-cleanup.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core/templates/jobs-cleanup.yaml
@@ -1,30 +1,14 @@
 #
-# Copyright © 2025. Cloud Software Group, Inc.
+# Copyright © 2026 Cloud Software Group, Inc.
 # This file is subject to the license terms contained
 # in the license file that is distributed with this file.
 #
 
-{{/* Cleanup RBAC resources - needed for both DB cleanup and self-signed cert cleanup jobs */}}
+{{/* Cleanup resources - needed for both DB cleanup and self-signed cert cleanup jobs */}}
 {{- if or (and .Values.global.tibco.manageDbSchema (eq .Values.global.tibco.is_replica_region false)) (eq .Values.global.tibco.self_hosted_deployment true) }}
 
-{{- if empty .Values.global.tibco.serviceAccount }}
-{{/* Dedicated ServiceAccount for cleanup jobs */}}
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ include "tp-control-plane.consts.appName" . }}-cleanup-sa
-  namespace: {{ include "tp-control-plane.consts.namespace" . }}
-  annotations:
-    "helm.sh/hook": post-delete
-    "helm.sh/hook-weight": "1"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-  labels:
-    {{- include "tp-control-plane.shared.labels.standard" . | nindent 4 }}
-{{- end }}
-
 ---
-{{/* Dedicated Role for cleanup jobs */}}
-{{- if .Values.global.tibco.rbac.infra }}
+{{/* Role for cleanup jobs */}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -40,11 +24,9 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["get", "list", "delete"]
-{{- end }}
 
 ---
-{{/* Dedicated RoleBinding for cleanup jobs */}}
-{{- if .Values.global.tibco.rbac.infra }}
+{{/* RoleBinding for cleanup jobs */}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -62,9 +44,8 @@ roleRef:
   name: {{ include "tp-control-plane.consts.appName" . }}-cleanup-role
 subjects:
 - kind: ServiceAccount
-  name: {{ include "tp-cp-core.cleanup.serviceAccountName" . }}
+  name: {{ .Values.global.tibco.serviceAccount | default "control-plane-sa" }}
   namespace: {{ include "tp-control-plane.consts.namespace" . }}
-{{- end }}
 
 ---
 {{/* Post-delete hook version of container registry secret for cleanup jobs */}}
@@ -279,7 +260,7 @@ spec:
       securityContext:
         {{- toYaml .Values.global.podSecurityContext | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "tp-cp-core.cleanup.serviceAccountName" . }}
+      serviceAccountName: {{ .Values.global.tibco.serviceAccount | default "control-plane-sa" }}
       nodeSelector:
         kubernetes.io/os: linux
       restartPolicy: Never
@@ -293,7 +274,7 @@ spec:
         securityContext:
           {{- toYaml .Values.global.containerSecurityContextTpcpcoreJob | nindent 10 }}
         {{- end }}
-        image: '{{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}/core-cp-scripts:{{ include "cp-core-scripts.buildNumber" . }}'
+        image: '{{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}/core-cp-scripts:{{ .Values.global.tibco.commonImages.cpScripts.tag }}'
         imagePullPolicy: IfNotPresent
         env:
         - name: DB_PREFIX
@@ -375,7 +356,7 @@ spec:
       securityContext:
         {{- toYaml .Values.global.podSecurityContext | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "tp-cp-core.cleanup.serviceAccountName" . }}
+      serviceAccountName: {{ .Values.global.tibco.serviceAccount | default "control-plane-sa" }}
       nodeSelector:
         kubernetes.io/os: linux
       restartPolicy: Never
@@ -389,7 +370,7 @@ spec:
         securityContext:
           {{- toYaml .Values.global.containerSecurityContextTpcpcoreJob | nindent 10 }}
         {{- end }}
-        image: '{{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}/core-cp-scripts:{{ include "cp-core-scripts.buildNumber" . }}'
+        image: '{{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}/core-cp-scripts:{{ .Values.global.tibco.commonImages.cpScripts.tag }}'
         imagePullPolicy: IfNotPresent
         env:
         - name: POD_NAMESPACE

--- a/charts/tibco-cp-base/charts/tp-cp-core/templates/jobs.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core/templates/jobs.yaml
@@ -37,7 +37,7 @@ spec:
         securityContext:
           {{- toYaml .Values.global.containerSecurityContextTpcpcoreJob | nindent 10 }}
         {{- end }}
-        image: '{{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}/core-cp-scripts:{{ include "cp-core-scripts.buildNumber" . }}'
+        image: '{{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}/core-cp-scripts:{{ .Values.global.tibco.commonImages.cpScripts.tag }}'
         imagePullPolicy: IfNotPresent
         env:
         - name: DB_PREFIX
@@ -164,7 +164,7 @@ spec:
         securityContext:
           {{- toYaml .Values.global.containerSecurityContextTpcpcoreJob | nindent 10 }}
         {{- end }}
-        image: '{{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}/core-cp-scripts:{{ include "cp-core-scripts.buildNumber" . }}'
+        image: '{{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}/core-cp-scripts:{{ .Values.global.tibco.commonImages.cpScripts.tag }}'
         imagePullPolicy: IfNotPresent
         workingDir: /tmp # Use tmp folder which is mounted to this container and is writable
         env:

--- a/charts/tibco-cp-base/charts/tp-cp-core/templates/tsc-dns-cm.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core/templates/tsc-dns-cm.yaml
@@ -49,4 +49,5 @@ data:
   TP_CP_BW_MCP_SERVER_HOST: {{ include "tpcontrol-plane.consts.tpCpBwMcpServerServiceName" . }}
   TP_CP_FLOGO_MCP_SERVER_HOST: {{ include "tpcontrol-plane.consts.tpCpFlogoMcpServerServiceName" . }}
   TP_O11Y_MCP_SERVER_HOST: {{ include "tpcontrol-plane.consts.tpO11yMcpServerServiceName" . }}
+  TP_AI_AGENT_HOST: {{ include "tpcontrol-plane.consts.tpAiAgentServiceName" . }}
 

--- a/charts/tibco-cp-base/charts/tp-cp-core/values.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-core/values.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright © 2024. Cloud Software Group, Inc.
+# Copyright © 2026 Cloud Software Group, Inc.
 # This file is subject to the license terms contained
 # in the license file that is distributed with this file.
 #
@@ -18,11 +18,6 @@ global:
     # Set to false to disable DB script execution if you want to run scripts manually outside of the chart
     # Default value is true
     manageDbSchema: true
-    rbac:
-      # Flag to enable or disable creation of RBAC resources (ServiceAccount, Role, RoleBinding)
-      # Set to false if you want to manage RBAC resources externally
-      # Default value is true
-      infra: true
     containerRegistry:
       url: ""
       username: ""
@@ -55,16 +50,6 @@ global:
       password: ""
       pullLatestCharts: false
       certificateSecretName: ""
-    logging:
-      fluentbit:
-        enabled: true
-        image:
-          name: "common-fluentbit"
-          tag: 4.2.2
-    check_dependencies:
-      distroless_debian:
-        name: "common-distroless-base-debian-debug"
-        tag: 12.13
     self_hosted_deployment: true
     is_replica_region: false
     finops: "disable"

--- a/charts/tibco-cp-base/charts/tp-cp-infra/Chart.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-infra/Chart.yaml
@@ -7,6 +7,6 @@
 
 apiVersion: v2
 name: tp-cp-infra
-version: 1.15.0
-appVersion: 1.15.0
+version: 1.16.0
+appVersion: 1.16.0
 description: TIBCO Platform Control Plane Infra chart

--- a/charts/tibco-cp-base/charts/tp-cp-infra/templates/deployment.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-infra/templates/deployment.yaml
@@ -160,6 +160,8 @@ spec:
         {{- end }}
           - name: CREATE_JFROG_ACCOUNT_PER_SUBSCRIPTION
             value: "{{ .Values.dpContainerRegistries.jfrog.enabled }}"
+          - name: FLUENTBIT_IMAGE_TAG
+            value: {{ .Values.global.tibco.commonImages.fluentbit.tag | quote }}
         {{- if .Values.dpContainerRegistries.jfrog.enabled }}
           - name: JFROG_MOTHERSHIP_FQDN
             valueFrom:
@@ -263,8 +265,8 @@ spec:
             value: {{ .Values.logLevel }}
 {{- if .Values.global.tibco.logging.fluentbit.enabled }}
       - name: fluentbit
-        image: {{ include "tp-cp-infra.image.registry" .}}{{"/"}}{{ include "tp-cp-infra.image.repository" .}}{{"/"}}{{ .Values.global.tibco.logging.fluentbit.image.name }}:{{ .Values.global.tibco.logging.fluentbit.image.tag }}
-        imagePullPolicy: {{ .Values.global.tibco.logging.fluentbit.image.pullPolicy }}
+        image: {{ include "tp-cp-infra.image.registry" .}}{{"/"}}{{ include "tp-cp-infra.image.repository" .}}{{"/common-fluentbit"}}:{{ .Values.global.tibco.commonImages.fluentbit.tag }}
+        imagePullPolicy: IfNotPresent
         {{- if .Values.securityContext }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}

--- a/charts/tibco-cp-base/charts/tp-cp-infra/values.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-infra/values.yaml
@@ -11,9 +11,12 @@ logLevel: "info"
 
 dpMetadata:
   dpConfigureNamespaceChartName: "dp-configure-namespace"
-  dpConfigureNamespaceChartVersion: "*"
+  dpConfigureNamespaceChartVersion: "1.16.0"
+  dpConfigureNamespaceAppVersion: "1.16.0"
   dpCoreInfrastructureChartName: "dp-core-infrastructure"
-  dpCoreInfrastructureChartVersion: "*"
+  dpCoreInfrastructureChartVersion: "1.16.4"
+  dpCoreInfrastructureAppVersion: "1.16.0"
+
   components:
     services:
       - name: "tp-tibtunnel"
@@ -64,11 +67,11 @@ hpa:
 image:
   infra-compute-services:
     name: infra-compute-services
-    tag: 719-distroless
+    tag: 725-distroless
     pullPolicy: IfNotPresent
   infra-alerts-services:
     name: infra-alerts-service
-    tag: 182-distroless
+    tag: 190-distroless
     pullPolicy: IfNotPresent
 
 # no of replicas
@@ -123,29 +126,6 @@ global:
     # control plane instance Id. Ex: prod, stag, p01, s01. This is to identify multiple cp installation in same cluster.
     # lowercase alphanumeric string of max 5 chars
     controlPlaneInstanceId: ""
-    
-    # The fluentbit configuration section.
-    # It specifies that the fluentbit should not run as a non-root user and the user ID should be 0 (root).
-    # Privilege escalation is not allowed for security reasons.
-    # Additionally, it drops all capabilities, which is a common security practice to minimize potential risks.
-    # GitHub issue: https://github.com/fluent/fluent-bit/issues/872#issuecomment-827763207, https://github.com/kyma-project/kyma/pull/11657/files
-    logging:
-      fluentbit:
-        enabled: true
-        image:
-          name: "common-fluentbit"
-          registry: ""
-          repo: ""
-          tag: 4.2.2
-          pullPolicy: IfNotPresent
-        resources:
-          requests:
-            cpu: 50m
-            memory: 100Mi
-          limits:
-            cpu: 100m
-            memory: 150Mi
-
 
   external:
     dnsTunnelDomain: ""

--- a/charts/tibco-cp-base/charts/tp-cp-integration-common/Chart.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-integration-common/Chart.yaml
@@ -4,10 +4,10 @@
 #
 apiVersion: v2
 name: tp-cp-integration-common
-version: 1.13.0
-appVersion: 1.13.0
+version: 1.16.0
+appVersion: 1.16.0
 description: TIBCO Platform integration prerequesites
 dependencies:
   - name: fileserver
-    version: "1.13.*"
+    version: "1.16.*"
     condition: fileserver.enabled

--- a/charts/tibco-cp-base/charts/tp-cp-integration-common/charts/fileserver/Chart.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-integration-common/charts/fileserver/Chart.yaml
@@ -6,8 +6,8 @@ apiVersion: v2
 name: fileserver
 description: Integration fileserver
 type: application
-version: 1.13.0
-appVersion: "1.13.0"
+version: 1.16.0
+appVersion: "1.16.0"
 keywords:
   - tibco-platform
   - control-plane

--- a/charts/tibco-cp-base/charts/tp-cp-integration-common/charts/fileserver/values.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-integration-common/charts/fileserver/values.yaml
@@ -15,27 +15,6 @@ global:
     enableResourceConstraints: true
     useSingleNamespace: true
     serviceAccount: ""
-    # The fluentbit configuration section.
-    # It specifies that the fluentbit should not run as a non-root user and the user ID should be 0 (root).
-    # Privilege escalation is not allowed for security reasons.
-    # Additionally, it drops all capabilities, which is a common security practice to minimize potential risks.
-    # GitHub issue: https://github.com/fluent/fluent-bit/issues/872#issuecomment-827763207, https://github.com/kyma-project/kyma/pull/11657/files
-    logging:
-      fluentbit:
-        enabled: true
-        image:
-          name: "common-fluentbit"
-          registry: ""
-          repo: ""
-          tag: 4.0.8
-          pullPolicy: IfNotPresent
-        securityContext:
-          runAsNonRoot: false
-          runAsUser: 0
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - ALL
     proxy:
       http: ""
       https: ""

--- a/charts/tibco-cp-base/charts/tp-cp-integration-common/values.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-integration-common/values.yaml
@@ -15,27 +15,6 @@ global:
     enableResourceConstraints: true
     useSingleNamespace: true
     serviceAccount: ""
-    # The fluentbit configuration section.
-    # It specifies that the fluentbit should not run as a non-root user and the user ID should be 0 (root).
-    # Privilege escalation is not allowed for security reasons.
-    # Additionally, it drops all capabilities, which is a common security practice to minimize potential risks.
-    # GitHub issue: https://github.com/fluent/fluent-bit/issues/872#issuecomment-827763207, https://github.com/kyma-project/kyma/pull/11657/files
-    logging:
-      fluentbit:
-        enabled: true
-        image:
-          name: "common-fluentbit"
-          registry: ""
-          repo: ""
-          tag: 4.0.8
-          pullPolicy: IfNotPresent
-        securityContext:
-          runAsNonRoot: false
-          runAsUser: 0
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - ALL
     proxy:
       http: ""
       https: ""

--- a/charts/tibco-cp-base/charts/tp-cp-o11y/Chart.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-o11y/Chart.yaml
@@ -8,5 +8,5 @@
 #
 apiVersion: v2
 name: tp-cp-o11y
-version: 1.15.19
-appVersion: "1.15.0"
+version: 1.16.10
+appVersion: "1.16.0"

--- a/charts/tibco-cp-base/charts/tp-cp-o11y/templates/_helpers.tpl
+++ b/charts/tibco-cp-base/charts/tp-cp-o11y/templates/_helpers.tpl
@@ -82,6 +82,8 @@ app.kubernetes.io/version: {{ .Chart.AppVersion }}
   {{- default "" .Values.global.tibco.containerRegistry.repository }}
 {{- end -}}
 
+{{- define "tp-cp-o11y.consts.cp.db.configuration" }}provider-cp-database-config{{ end -}}
+
 {{/* Service account configured for control plane. fail if service account not exist */}}
 {{- define "tp-cp-o11y.service-account-name" }}
 {{- if .Values.serviceAccount }}

--- a/charts/tibco-cp-base/charts/tp-cp-o11y/templates/deployment.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-o11y/templates/deployment.yaml
@@ -39,6 +39,43 @@ spec:
       serviceAccountName: {{ include "tp-cp-o11y.service-account-name" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: check-sql-schema-version
+          image: '{{ include "cp-core-configuration.container-registry" .}}{{"/"}}{{ include "cp-core-configuration.image-repository" . }}/core-cp-scripts:{{ .Values.global.tibco.commonImages.cpScripts.tag }}'
+          {{- if .Values.securityContext }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.checkPermissionEngine.resources | nindent 12 }}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: DB_PREFIX
+              value: {{ .Values.global.tibco.controlPlaneInstanceId }}_
+            - name: PGHOST
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.global.tibco.tcta.TCTA_DB_CONFIGURATION }}
+                  {{- if eq .Values.global.tibco.is_replica_region true }}
+                  key: MasterWriterHost
+                  {{- else }}
+                  key: DBHost
+                  {{- end }}
+            - name: PGPORT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.global.tibco.tcta.TCTA_DB_CONFIGURATION }}
+                  key: DBPort
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: tasdataserver-postgres-credential
+                  key: PGPASSWORD
+          command:
+            - "/bin/bash"
+            - "-c"
+            - |
+              /opt/tibco/tsc/scripts/postgres-helper.bash check-schema-version tasdataserver
       containers:
         - name: tp-cp-o11y
           image: {{ include "tp-cp-o11y.image.registry" .}}{{"/"}}{{ include "tp-cp-o11y.image.repository" .}}{{"/"}}{{ .Values.image.name }}:{{ .Values.image.tag }}
@@ -67,6 +104,62 @@ spec:
               value: {{ include "tp-cp-o11y.cp-dp-url" . }}
             - name: CP_O11Y_DPCACHE_ENABLED
               value: "true"
+            - name: PGHOST
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.global.tibco.tcta.TCTA_DB_CONFIGURATION }}
+                  {{- if eq .Values.global.tibco.is_replica_region true }}
+                  key: MasterWriterHost
+                  {{- else }}
+                  key: DBHost
+                  {{- end }}
+            - name: PGPORT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.global.tibco.tcta.TCTA_DB_CONFIGURATION }}
+                  key: DBPort
+            - name: READ_PGHOST
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.global.tibco.tcta.TCTA_DB_CONFIGURATION }}
+                  {{- if eq .Values.global.tibco.is_replica_region true }}
+                  key: LocalReaderHost
+                  {{- else }}
+                  key: DBHost
+                  {{- end }}
+            - name: READ_PGPORT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.global.tibco.tcta.TCTA_DB_CONFIGURATION }}
+                  key: DBPort
+            - name: WRITE_POSTGRES_ENDPOINT_URL
+              value: "$(PGHOST):$(PGPORT)"
+            - name: READ_POSTGRES_ENDPOINT_URL
+              value: "$(READ_PGHOST):$(READ_PGPORT)"
+            - name: POSTGRES_DATABASE_SSL_MODE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "tp-cp-o11y.consts.cp.db.configuration" . }}
+                  key: DBSSLMode
+            - name: POSTGRES_DATABASE_SSL_CERT
+              value: ""
+            - name: POSTGRES_DATABASE_SSL_KEY
+              value: ""
+            - name: POSTGRES_DATABASE_SSL_ROOT_CERT
+              value: /private/tsc/certificates/{{ .Values.global.tibco.db_ssl_root_cert_filename }}
+            - name: TCTA_DTS_DB_HOSTPORT
+              value: "$(PGHOST):$(PGPORT)"
+            - name: TCTA_DTS_DB_USER_NAME
+              value: {{ include "tp-cp-o11y.cp-instance-id" . }}_tctadataserveruser
+            - name: TCTA_DTS_DB_USER_PWD
+              valueFrom:
+                secretKeyRef:
+                  name: tasdataserver-postgres-credential
+                  key: PGPASSWORD
+            - name: TCTA_DTS_DB_NAME
+              value: {{ include "tp-cp-o11y.cp-instance-id" . }}_tctadataserver
+            - name: TCTA_DTS_DB_SCHEMA_NAME
+              value: {{ include "tp-cp-o11y.cp-instance-id" . }}_tctadataserver
             - name: NAMESPACE
               valueFrom:
                 fieldRef:
@@ -122,6 +215,11 @@ spec:
             - name: cp-otel-secret
               readOnly: true
               mountPath: "/o11y/secrets"
+{{- if ne .Values.global.external.db_ssl_mode "disable" }}
+            - mountPath: /private/tsc/certificates
+              name: db-ssl-cert-vol
+              readOnly: true
+{{- end }}
   {{- if .Values.o11ymcpserver.enabled }}
         - name: o11y-mcp-server
           image: {{ include "tp-cp-o11y.image.registry" .}}{{"/"}}{{ include "tp-cp-o11y.image.repository" .}}{{"/"}}{{ .Values.o11ymcpserver.image.name }}:{{ .Values.o11ymcpserver.image.tag }}
@@ -168,8 +266,8 @@ spec:
   {{- end }}
   {{- if .Values.global.tibco.logging.fluentbit.enabled }}
         - name: fluentbit
-          image: {{ include "tp-cp-o11y.image.registry" .}}{{"/"}}{{ include "tp-cp-o11y.image.repository" .}}{{"/"}}{{ .Values.global.tibco.logging.fluentbit.image.name }}:{{ .Values.global.tibco.logging.fluentbit.image.tag }}
-          imagePullPolicy: {{ .Values.global.tibco.logging.fluentbit.image.pullPolicy }}
+          image: {{ include "tp-cp-o11y.image.registry" .}}{{"/"}}{{ include "tp-cp-o11y.image.repository" .}}{{"/common-fluentbit"}}:{{ .Values.global.tibco.commonImages.fluentbit.tag }}
+          imagePullPolicy: IfNotPresent
           {{- if .Values.securityContext }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -251,6 +349,11 @@ spec:
         - name: config-volume
           configMap:
             name: {{ include "tp-cp-o11y.consts.appName" . }}-fluentbit-config
+{{- end }}
+{{- if ne .Values.global.external.db_ssl_mode "disable" }}
+        - name: db-ssl-cert-vol
+          secret:
+            secretName: {{ .Values.global.tibco.db_ssl_root_cert_secretname }}
 {{- end }}
         - name: cp-otel-config
           configMap:

--- a/charts/tibco-cp-base/charts/tp-cp-o11y/templates/o11y-exporter.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-o11y/templates/o11y-exporter.yaml
@@ -15,7 +15,7 @@ metadata:
 data:
   version.json: |
     {
-      "capabilityVersion": "1.15.0",
+      "capabilityVersion": "1.16.0",
       "minCPVersion": "1.2.0",
       "maxCPVersion": "",
       "releaseDate": {{ .Values.capabilities.o11y.withResources.releaseDate | quote }},
@@ -379,7 +379,7 @@ data:
                         - set(resource.attributes["pod_name"], resource.attributes["k8s.pod.name"])
                         - set(resource.attributes["pod_uid"], resource.attributes["k8s.pod.uid"])
                         - set(resource.attributes["pod_start_time"], resource.attributes["k8s.pod.start_time"])
-                        - set(resource.attributes["workload_type"], "user-app") where IsMatch(resource.attributes["app_type"], "msg-*") or IsMatch(body["host_cloud_type"], "control-tower")
+                        - set(resource.attributes["workload_type"], "user-app") where IsMatch(resource.attributes["app_type"], "msg-*") or IsMatch(body["host_cloud_type"], "control-tower") or IsMatch(body["app_type"], "bw5")
                         - set(resource.attributes["app_id"], body["app_id"]) where IsMatch(body["host_cloud_type"], "control-tower")
                         - set(resource.attributes["app_id"], resource.attributes["capability_instance_id"]) where IsMatch(resource.attributes["app_type"], "msg-*")
                         - set(resource.attributes["server_name"], resource.attributes["pod_name"]) where IsMatch(resource.attributes["app_type"], "msg-*")
@@ -401,6 +401,7 @@ data:
                         - set(body["app_version"], resource.attributes["app_version"])
                         - set(body["capability_instance_id"], resource.attributes["capability_instance_id"])
                         - set(body["dataplane_id"], resource.attributes["dataplane_id"])
+                        - set(body["dataplane_id"], "${DATAPLANE-ID}") where resource.attributes["dataplane_id"] == nil
                         - set(body["pod_name"], resource.attributes["pod_name"])
                         - set(body["pod_namespace"], resource.attributes["pod_namespace"])
                         - set(body["pod_uid"], resource.attributes["pod_uid"])
@@ -1366,8 +1367,8 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: o11y
-        image: {{ include "tp-cp-o11y.image.registry" .}}{{"/"}}{{ include "tp-cp-o11y.image.repository" .}}{{"/"}}{{ .Values.job.image.name }}:{{ .Values.job.image.tag}}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: {{ include "tp-cp-o11y.image.registry" .}}{{"/"}}{{ include "tp-cp-o11y.image.repository" .}}{{"/common-distroless-base-debian-debug"}}:{{ .Values.global.tibco.commonImages.distrolessDebug.tag }}
+        imagePullPolicy: IfNotPresent
         {{- if .Values.securityContext }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
@@ -1386,7 +1387,7 @@ spec:
         - name: RECIPE_TARGET_LOCATION
           value: "/private/tsc/config/capabilities/platform"
         - name: RECIPE_RELEASE_VERSION
-          value: "1.15.0"
+          value: "1.16.0"
         - name: SPACE_SEPARATED_UNSUPPORTED_RECIPE_VERSIONS
           value: ""
         - name: OVERWRITE_RECIPE

--- a/charts/tibco-cp-base/charts/tp-cp-o11y/templates/o11y.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-o11y/templates/o11y.yaml
@@ -15,7 +15,7 @@ metadata:
 data:
   version.json: |
     {
-      "capabilityVersion": "1.15.0",
+      "capabilityVersion": "1.16.0",
       "minCPVersion": "1.2.0",
       "maxCPVersion": "",
       "releaseDate": {{ .Values.capabilities.o11y.default.releaseDate | quote }},
@@ -1005,8 +1005,8 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: o11y
-        image: {{ include "tp-cp-o11y.image.registry" .}}{{"/"}}{{ include "tp-cp-o11y.image.repository" .}}{{"/"}}{{ .Values.job.image.name }}:{{ .Values.job.image.tag}}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: {{ include "tp-cp-o11y.image.registry" .}}{{"/"}}{{ include "tp-cp-o11y.image.repository" .}}{{"/common-distroless-base-debian-debug"}}:{{ .Values.global.tibco.commonImages.distrolessDebug.tag }}
+        imagePullPolicy: IfNotPresent
         {{- if .Values.securityContext }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
@@ -1025,7 +1025,7 @@ spec:
         - name: RECIPE_TARGET_LOCATION
           value: "/private/tsc/config/capabilities/infra"
         - name: RECIPE_RELEASE_VERSION
-          value: "1.15.0"
+          value: "1.16.0"
         - name: SPACE_SEPARATED_UNSUPPORTED_RECIPE_VERSIONS
           value: ""
         - name: OVERWRITE_RECIPE

--- a/charts/tibco-cp-base/charts/tp-cp-o11y/values.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-o11y/values.yaml
@@ -20,6 +20,10 @@ global:
     controlPlaneInstanceId: ""
     useSingleNamespace: true
     enableResourceConstraints: true
+    tcta:
+      TCTA_DB_CONFIGURATION: provider-cp-database-config
+    db_ssl_root_cert_secretname: "db-ssl-root-cert"
+    db_ssl_root_cert_filename: "db_ssl_root.cert"
     logging:
       # The fluentbit configuration section.
       # It specifies that the fluentbit should not run as a non-root user and the user ID should be 0 (root).
@@ -32,7 +36,7 @@ global:
           name: "common-fluentbit"
           registry: ""
           repo: ""
-          tag: 4.2.2
+          tag: 4.2.3
           pullPolicy: IfNotPresent
         securityContext:
           runAsNonRoot: false
@@ -79,7 +83,7 @@ probes:
 image:
   name: "o11y-service"
   pullPolicy: IfNotPresent
-  tag: 3758
+  tag: 3965
 
 tibcoRouter:
   path: /o11y
@@ -107,7 +111,7 @@ capabilities:
       releaseNotes: "Enhancements, Bug fixes, etc."
       # helm chart and image version for o11y service, default helm chart version is latest
       o11yservice:
-        version: "1.15.19"
+        version: "1.16.10"
       # helm chart and image version for opentelemetry collector, default helm chart version is latest
       opentelemetryCollector:
         version: "0.140.3"
@@ -125,18 +129,13 @@ capabilities:
       releaseNotes: "Enhancements, Bug fixes, etc."
       # helm chart and image version for o11y service, default helm chart version is latest
       o11yservice:
-        version: "1.15.19"
+        version: "1.16.10"
       # helm chart and image version for opentelemetry collector, default helm chart version is latest
       opentelemetryCollector:
         version: "0.140.3"
       # helm chart and image version for jaeger, default helm chart version is latest
       jaeger:
         version: "0.72.40"
-job:
-  image:
-    name: common-distroless-base-debian-debug
-    tag: 12.13
-    pullPolicy: IfNotPresent
 
 # Resources
 # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -175,7 +174,7 @@ o11ymcpserver:
   enabled: false
   image:
     name: o11y-mcp-service
-    tag: "106"
+    tag: "186"
   resources:
     requests:
       cpu: 100m
@@ -189,3 +188,12 @@ audittrail:
   # - This allows Audit Trail functionality to be disabled when otel-service on CP is enabled
   # - By default, Audit Trail is enabled
   enabled: true
+
+checkPermissionEngine:
+  resources:
+    requests:
+      cpu: "10m"
+      memory: "20Mi"
+    limits:
+      cpu: "30m"
+      memory: "40Mi"

--- a/charts/tibco-cp-base/charts/tp-cp-prometheus/Chart.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-prometheus/Chart.yaml
@@ -3,7 +3,7 @@
 # in the license file that is distributed with this file.
 
 apiVersion: v2
-appVersion: "1.15.0"
+appVersion: "1.16.0"
 description: TIBCO Platform Control Plane - Hawk Infra Bundle
 # dependencies:
 #   - name: prometheus
@@ -19,4 +19,4 @@ keywords:
 maintainers:
   - name: TIBCO Cloud Hawk Team
 name: tp-cp-prometheus
-version: "1.15.0"
+version: "1.16.0"

--- a/charts/tibco-cp-base/charts/tp-cp-prometheus/values.yaml
+++ b/charts/tibco-cp-base/charts/tp-cp-prometheus/values.yaml
@@ -43,21 +43,6 @@ global:
           - CAP_NET_RAW
           - ALL
 
-  # The fluentbit configuration section.
-  # It specifies that the fluentbit should not run as a non-root user and the user ID should be 0 (root).
-  # Privilege escalation is not allowed for security reasons.
-  # Additionally, it drops all capabilities, which is a common security practice to minimize potential risks.
-  # GitHub issue: https://github.com/fluent/fluent-bit/issues/872#issuecomment-827763207, https://github.com/kyma-project/kyma/pull/11657/files
-  fluentbit:
-    securityContext:
-      runAsNonRoot: false
-      runAsUser: 0
-      allowPrivilegeEscalation: false
-      capabilities:
-        drop:
-          - CAP_NET_RAW
-          - ALL
-
   # Prometheus Discovery side car resource values for production like setup
   resources:
     prometheusds:
@@ -259,7 +244,7 @@ server:
       name: hawk-prometheus-discoveryservice
       pullPolicy: IfNotPresent
       # tag: 120
-      tag: "1.15.0.30"
+      tag: "1.16.0.6"
     promDSLivenessProbe:
       successThreshold: 1
       failureThreshold: 5

--- a/charts/tibco-cp-base/charts/tp-dp-proxy/Chart.yaml
+++ b/charts/tibco-cp-base/charts/tp-dp-proxy/Chart.yaml
@@ -6,5 +6,5 @@
 
 apiVersion: v2
 name: tp-dp-proxy
-version: 1.15.0
-appVersion: 1.15.0
+version: 1.16.0
+appVersion: 1.16.0

--- a/charts/tibco-cp-base/charts/tp-dp-proxy/templates/deployment.yaml
+++ b/charts/tibco-cp-base/charts/tp-dp-proxy/templates/deployment.yaml
@@ -97,8 +97,8 @@ spec:
             value: {{ .Values.proxyConfigCacheDisabled | quote }}
 {{- if .Values.global.tibco.logging.fluentbit.enabled }}
       - name: fluentbit
-        image: {{ include "tp-dp-proxy.image.registry" .}}{{"/"}}{{ include "tp-dp-proxy.image.repository" .}}{{"/"}}{{ .Values.global.tibco.logging.fluentbit.image.name }}:{{ .Values.global.tibco.logging.fluentbit.image.tag }}
-        imagePullPolicy: {{ .Values.global.tibco.logging.fluentbit.image.pullPolicy }}
+        image: {{ include "tp-dp-proxy.image.registry" .}}{{"/"}}{{ include "tp-dp-proxy.image.repository" .}}{{"/common-fluentbit"}}:{{ .Values.global.tibco.commonImages.fluentbit.tag }}
+        imagePullPolicy: IfNotPresent
         {{- if .Values.securityContext }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}

--- a/charts/tibco-cp-base/charts/tp-dp-proxy/templates/jobs.yaml
+++ b/charts/tibco-cp-base/charts/tp-dp-proxy/templates/jobs.yaml
@@ -35,7 +35,7 @@ spec:
         - name: {{ include "tp-dp-proxy.container-registry.secret" . }}
       containers:
       - name: rollout-restart
-        image: {{ include "tp-dp-proxy.image.registry" .}}{{"/"}}{{ include "tp-dp-proxy.image.repository" .}}{{"/"}}{{ .Values.cpScriptsImage.name }}:{{ .Values.cpScriptsImage.tag }}
+        image: {{ include "tp-dp-proxy.image.registry" .}}{{"/"}}{{ include "tp-dp-proxy.image.repository" .}}{{"/core-cp-scripts"}}:{{ .Values.global.tibco.commonImages.cpScripts.tag }}
         imagePullPolicy: IfNotPresent
         {{- if .Values.securityContext }}
         securityContext:

--- a/charts/tibco-cp-base/charts/tp-dp-proxy/values.yaml
+++ b/charts/tibco-cp-base/charts/tp-dp-proxy/values.yaml
@@ -7,13 +7,8 @@
 
 image:
   name: infra-dp-proxy
-  tag: 143-distroless
+  tag: 150-distroless
   pullPolicy: IfNotPresent
-
-# Image for post-upgrade job (core-cp-scripts image with kubectl)
-cpScriptsImage:
-  name: core-cp-scripts
-  tag: "9153"
 
 # Resource values for production like setup
 resources:
@@ -72,24 +67,3 @@ global:
     # control plane instance Id. Ex: prod, stag, p01, s01. This is to identify multiple cp installation in same cluster.
     # lowercase alphanumeric string of max 5 chars
     controlPlaneInstanceId: ""
-    # The fluentbit configuration section.
-    # It specifies that the fluentbit should not run as a non-root user and the user ID should be 0 (root).
-    # Privilege escalation is not allowed for security reasons.
-    # Additionally, it drops all capabilities, which is a common security practice to minimize potential risks.
-    # GitHub issue: https://github.com/fluent/fluent-bit/issues/872#issuecomment-827763207, https://github.com/kyma-project/kyma/pull/11657/files
-    logging:
-      fluentbit:
-        enabled: true
-        image:
-          name: "common-fluentbit"
-          registry: ""
-          repo: ""
-          tag: 4.0.3
-          pullPolicy: IfNotPresent
-        resources:
-          requests:
-            cpu: 50m
-            memory: 100Mi
-          limits:
-            cpu: 100m
-            memory: 150Mi

--- a/charts/tibco-cp-base/templates/cluster-role-binding.yaml
+++ b/charts/tibco-cp-base/templates/cluster-role-binding.yaml
@@ -1,12 +1,11 @@
 #
-# Copyright © 2023 - 2024. Cloud Software Group, Inc.
+# Copyright © 2026 Cloud Software Group, Inc.
 # This file is subject to the license terms contained
 # in the license file that is distributed with this file.
 #
 
 
 {{/* all cluster role bindings are created at once during the deployment of the chart in the namespace */}}
-{{- if .Values.global.tibco.rbac.infra }}
 {{- if not .Values.global.tibco.useSingleNamespace }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -22,6 +21,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "tibco-cp-base.serviceAccount" . }}
     namespace: {{ .Release.Namespace }}
-
-{{- end -}}
 {{- end -}}

--- a/charts/tibco-cp-base/templates/cluster-role.yaml
+++ b/charts/tibco-cp-base/templates/cluster-role.yaml
@@ -1,12 +1,11 @@
 #
-# Copyright © 2023 - 2024. Cloud Software Group, Inc.
+# Copyright © 2026 Cloud Software Group, Inc.
 # This file is subject to the license terms contained
 # in the license file that is distributed with this file.
 #
 
 
 {{/* all cluster roles are created at once during the deployment of the chart in the namespace */}}
-{{- if .Values.global.tibco.rbac.infra }}
 {{- if not .Values.global.tibco.useSingleNamespace }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -39,5 +38,4 @@ rules:
 - apiGroups: ["cloud.tibco.com"]
   resources: ["tibcotunnelroutes", "tibcotunnelroutes/status"]
   verbs: ["*"]
-{{- end -}}
 {{- end -}}

--- a/charts/tibco-cp-base/templates/env.yaml
+++ b/charts/tibco-cp-base/templates/env.yaml
@@ -33,15 +33,6 @@ data:
   {{- if .Values.global.tibco.containerRegistry.certificateSecret }}
   CP_CONTAINER_REGISTRY_CERTIFICATE_SECRET: {{ .Values.global.tibco.containerRegistry.certificateSecret | quote }}
   {{- end }}
-  {{- if .Values.global.tibco.proxy.httpProxy }}
-  CP_HTTP_PROXY: {{ .Values.global.tibco.proxy.httpProxy | quote }}
-  {{- end }}
-  {{- if .Values.global.tibco.proxy.httpsProxy }}
-  CP_HTTPS_PROXY: {{ .Values.global.tibco.proxy.httpsProxy | quote }}
-  {{- end }}
-  {{- if .Values.global.tibco.proxy.noProxy }}
-  CP_NO_PROXY: {{ .Values.global.tibco.proxy.noProxy | quote }}
-  {{- end }}
   CP_ENABLE_HYBRID_CONNECTIVITY: {{ .Values.global.tibco.hybridConnectivity.enabled | quote }}
 
 ---

--- a/charts/tibco-cp-base/templates/role-binding.yaml
+++ b/charts/tibco-cp-base/templates/role-binding.yaml
@@ -1,12 +1,11 @@
 #
-# Copyright © 2023 - 2024. Cloud Software Group, Inc.
+# Copyright © 2026 Cloud Software Group, Inc.
 # This file is subject to the license terms contained
 # in the license file that is distributed with this file.
 #
 
 
 {{/* all cluster role bindings are created at once during the deployment of the chart in the namespace */}}
-{{- if .Values.global.tibco.rbac.infra }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -21,4 +20,3 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "tibco-cp-base.serviceAccount" . }}
     namespace: {{ .Release.Namespace }}
-{{- end -}}

--- a/charts/tibco-cp-base/templates/role.yaml
+++ b/charts/tibco-cp-base/templates/role.yaml
@@ -1,12 +1,11 @@
 #
-# Copyright © 2023 - 2024. Cloud Software Group, Inc.
+# Copyright © 2026 Cloud Software Group, Inc.
 # This file is subject to the license terms contained
 # in the license file that is distributed with this file.
 #
 
 
 {{/* all cluster roles are created at once during the deployment of the chart in the namespace */}}
-{{- if .Values.global.tibco.rbac.infra }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -56,4 +55,3 @@ rules:
 - apiGroups: ["batch"]
   resources: ["jobs"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-{{- end -}}

--- a/charts/tibco-cp-base/values.yaml
+++ b/charts/tibco-cp-base/values.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright © 2023 - 2025. Cloud Software Group, Inc.
+# Copyright © 2026 Cloud Software Group, Inc.
 # This file is subject to the license terms contained
 # in the license file that is distributed with this file.
 #
@@ -8,17 +8,11 @@ global:
   tibco:
     adminHostPrefix: "admin"
     is_replica_region: false
-    finops: "disable"
     serviceAccount: ""
     # Flag to enable or disable database jobs (upgrade and cleanup)
     # Set to false to disable DB script execution if you want to run scripts manually outside of the chart
     # Default value is true
     manageDbSchema: true
-    # k8s rbac required by the service account
-    rbac:
-      # create the rbac for base resources.
-      # set to true to create rbac resources for the service account (cluster role and binding), set to false if the service account already have the rbacs
-      infra: true
     containerRegistry:
       url: ""
       username: ""
@@ -90,10 +84,9 @@ global:
     useSingleNamespace: true
     enableResourceConstraints: true
     self_hosted_deployment: true
-    proxy:
-      httpProxy: ""
-      httpsProxy: ""
-      noProxy: ""
+    # Session timeout in seconds for idle session redirect and cookie timeout
+    # Default is 14400 seconds (4 hours). Allowable range is 600s (5 min) to 86400 (24 hours) exclusive
+    idleSessionTimeoutInSeconds: "14400"
     logging:
       # The fluentbit configuration section.
       # It specifies that the fluentbit should not run as a non-root user and the user ID should be 0 (root).
@@ -102,12 +95,6 @@ global:
       # GitHub issue: https://github.com/fluent/fluent-bit/issues/872#issuecomment-827763207, https://github.com/kyma-project/kyma/pull/11657/files
       fluentbit:
         enabled: true
-        image:
-          name: "common-fluentbit"
-          registry: ""
-          repo: ""
-          tag: 4.2.2
-          pullPolicy: IfNotPresent
         resources:
           requests:
             cpu: 50m
@@ -115,7 +102,15 @@ global:
           limits:
             cpu: 100m
             memory: 150Mi
-      repository: "tibco-platform-docker-prod"  # repository
+    # Common images
+    commonImages:
+      distrolessDebug:
+        tag: 13.3
+      cpScripts:
+        tag: "9203"
+      fluentbit:
+        tag: 4.2.3
+
   external:
     db_host: ""
     db_master_writer_host: ""
@@ -127,7 +122,6 @@ global:
     db_secret_name: "provider-cp-database-credentials"
     environment: "production"
     db_ssl_mode: "disable"
-    db_ssl_root_cert: ""
     fromAndReplyToEmailAddress: ""
     cronJobReportsEmailAlias: ""
     platformEmailNotificationCcAddresses: ""
@@ -179,12 +173,7 @@ global:
 tp-cp-cli:
   enabled: true
 
-# Default values for tp-cp-prometheus.
-tp-cp-prometheus:
-  enabled: true
-
 tp-cp-o11y:
-  enabled: true
   # Resource values for production-like setup
   # requests: Minimum amount of resources required for the application to run.
   # limits: Maximum amount of resources the application can use.
@@ -210,12 +199,6 @@ tp-cp-configuration:
 
 # Default values for tp-cp-infra.
 tp-cp-infra:
-  enabled: true
-  dpMetadata:
-    dpCoreInfrastructureChartVersion: "1.15.8"
-    dpCoreInfrastructureAppVersion: "1.15.0"
-    dpConfigureNamespaceChartVersion: "1.15.4"
-    dpConfigureNamespaceAppVersion: "1.15.0"
   # Resource values for production-like setup
   # requests: Minimum amount of resources required for the application to run.
   # limits: Maximum amount of resources the application can use.
@@ -229,7 +212,6 @@ tp-cp-infra:
         memory: 1024Mi  # Maximum memory allowed
 
 tp-cp-auditsafe:
-  enabled: true
   # Resource values for production-like setup
   # requests: Minimum amount of resources required for the application to run.
   # limits: Maximum amount of resources the application can use.
@@ -242,8 +224,6 @@ tp-cp-auditsafe:
       memory: 1024Mi  # Maximum memory allowed
 
 hybrid-proxy:
-  # switch to false to disable hybrid-proxy
-  enabled: true
   # HPO replica count
   # replicaCount: "1"  # Commented out - HPA manages replicas dynamically
   # Resource values for production-like setup
@@ -285,8 +265,6 @@ hybrid-proxy:
   #     external-dns.alpha.kubernetes.io/hostname: "*.cp1-tunnel.localhost.dataplanes.pro"
 
 router-operator:
-  # switch to false to disable router-operator
-  enabled: true
   # SecretNames for environment variables TSC_SESSION_KEY and DOMAIN_SESSION_KEY.
   # These secrets are used to store session keys securely.
   # The secrets should be created in the same namespace as the tibco-cp-base.
@@ -336,8 +314,6 @@ router-operator:
   #     external-dns.alpha.kubernetes.io/hostname: "*.cp1-my.localhost.dataplanes.pro"
 
 resource-set-operator:
-  # switch to false to disable resource-set-operator
-  enabled: true
   # Resource values for production-like setup
   # requests: Minimum amount of resources required for the application to run.
   # limits: Maximum amount of resources the application can use.
@@ -364,7 +340,4 @@ otel-collector:
       memory: 1024Mi  # Maximum memory allowed
 
 tp-cp-integration-common:
-  enabled: true
-
-tp-dp-proxy:
   enabled: true


### PR DESCRIPTION
This pull request updates the TIBCO Platform base chart and its subcharts to version 1.16.0, introduces dependency version bumps, and refactors how Fluent Bit logging sidecar images are configured and referenced. It also updates several container image tags and standardizes the use of common images for certain init and sidecar containers. Additionally, it removes redundant Fluent Bit configuration sections from values files, centralizing image references.

**Version Bumps and Dependency Updates:**

- Updated the main chart and all subcharts (`tibco-cp-base`, `hybrid-proxy`, `resource-set-operator`, `router-operator`, `tp-cp-alertmanager`, `tp-cp-auditsafe`, `tp-cp-cli`) to version 1.16.0, and updated their `appVersion` fields accordingly. [[1]](diffhunk://#diff-e53162a9459391cf32247fe33e075db3ea87ab30b1bdc035609314034601d9c6L11-R12) [[2]](diffhunk://#diff-7c492781fd0c61c891ae4f411df39049aa4882f78d015439bfdfc9e17de95261L10-R11) [[3]](diffhunk://#diff-d8ba44af6f473ff93137e803eabefe48ce065a155affc0c676144059200fe866L10-R11) [[4]](diffhunk://#diff-910087d7e246942a157c7c0104bcf38b99c1b773d796582be85f93d5920200d6L10-R11) [[5]](diffhunk://#diff-ad3f07185250a0d095dc6cd8cd4aca74407b64817d600b563f6d0bee3b453caeL20-R21) [[6]](diffhunk://#diff-6aac1dd74aa669d56b7e84c63f495ab745c5d22c07f82df4038b9d08c70e620fL9-R11) [[7]](diffhunk://#diff-850ef5f4098c8b403a98340cea50d1df477b377271be0415a5b37e15ce66f232L24-R30)
- Updated all dependency versions in `charts/tibco-cp-base/Chart.yaml` to the 1.16.* series, ensuring compatibility across the chart ecosystem.

**Fluent Bit Logging Sidecar Refactor:**

- Changed Fluent Bit sidecar image references in all affected deployments to use a centralized `global.tibco.commonImages.fluentbit.tag` and a standard image path (`/common-fluentbit`), with `imagePullPolicy: IfNotPresent`. [[1]](diffhunk://#diff-f592e155dd7c7452f2d35816fd463f84d15f8921c9d15b03aa545f1564c7609dL155-R156) [[2]](diffhunk://#diff-9c537e6f0dd32f52e8793bd07b43088328e65db8fb22714ccea11dfd49583acaL132-R133) [[3]](diffhunk://#diff-461d155cb8f6f68ec6b32db42caf7e648b4f9709e571f58f0ed021e72e254ac9L153-R154) [[4]](diffhunk://#diff-13c7cab2141ec90e9438f4d81dbb28576ac4f3f199e88c86a74320168218d69aL221-R222)
- Removed redundant Fluent Bit configuration blocks from the `values.yaml` files in all relevant subcharts, consolidating configuration and reducing duplication. [[1]](diffhunk://#diff-ecd76972c989b66ed16905250cdd3a507e4c0e4ddc2964494d30aa51ef380395L200-L220) [[2]](diffhunk://#diff-31e5c19602d3225ab9bd7e21ad4379bd79e2962c255d354d5e815b392b6f8641L68-L89) [[3]](diffhunk://#diff-2bffffb7afc39e9ff83400e8a5ff18add839ab240df4f886ae3a1e8131060fb1L206-L227) [[4]](diffhunk://#diff-7bcd2ee90460e9e17738ddd8d3f459b9548c19377b39e1bbf69a9c6c21aec0c9L111-L139) [[5]](diffhunk://#diff-7bcd2ee90460e9e17738ddd8d3f459b9548c19377b39e1bbf69a9c6c21aec0c9L185-L205)

**Container Image and Command Updates:**

- Updated main container image tags for `infra-hybrid-proxy`, `infra-resource-set-operator`, `infra-router`, and `infra-alertmanager` to newer versions. [[1]](diffhunk://#diff-ecd76972c989b66ed16905250cdd3a507e4c0e4ddc2964494d30aa51ef380395L43-R43) [[2]](diffhunk://#diff-31e5c19602d3225ab9bd7e21ad4379bd79e2962c255d354d5e815b392b6f8641L29-R29) [[3]](diffhunk://#diff-2bffffb7afc39e9ff83400e8a5ff18add839ab240df4f886ae3a1e8131060fb1L35-R35) [[4]](diffhunk://#diff-69b944fb5e5dff8a8e3799ff59f946e4e8e7dc7d18e8d225ebd46bcad72afde1L30-R30)
- Updated preStop lifecycle commands to use `/busybox/sleep` instead of `/bin/bash -c sleep`, simplifying dependencies and improving compatibility. [[1]](diffhunk://#diff-f592e155dd7c7452f2d35816fd463f84d15f8921c9d15b03aa545f1564c7609dL108-R108) [[2]](diffhunk://#diff-461d155cb8f6f68ec6b32db42caf7e648b4f9709e571f58f0ed021e72e254ac9L107-R107)
- Standardized the use of the `common-distroless-base-debian-debug` image for init containers and debug utilities, referencing a global image tag instead of per-chart values. [[1]](diffhunk://#diff-75aff9a7c0a49cb9ab668729b1597f5dbd5d28faeb9216dba27d4bd597057780L109-R110) [[2]](diffhunk://#diff-c128728f3f79e0d3af056f4c01152293c38ead2c91eea60e70da343521e6fa88L32-R33) [[3]](diffhunk://#diff-69b944fb5e5dff8a8e3799ff59f946e4e8e7dc7d18e8d225ebd46bcad72afde1L446-L449) [[4]](diffhunk://#diff-ec804e17afab6feb0fac0d8171831ee5e45d4a0a55403b6936cdf58aa3d030fdL13-L17)

These changes collectively improve maintainability, standardize image usage, and prepare the charts for the 1.16.0 release.