### PR TITLE
update devhub artifacts - remove alpha tag for 1.16.0 release

### DIFF
--- a/artifacts/developer-hub/developer-hub-1.16.0-charts.txt
+++ b/artifacts/developer-hub/developer-hub-1.16.0-charts.txt
@@ -1,4 +1,4 @@
-tibco-cp-devhub:1.16.0-alpha.6
+tibco-cp-devhub:1.16.0
 tibco-developer-hub:1.16.7
 tibcohub-contrib:1.16.0
 tibcohub-recipes:1.16.0


### PR DESCRIPTION
update devhub artifacts - remove alpha tag for 1.16.0 release