### PR TITLE
rds-improvements

### DIFF
--- a/charts/dp-config-aws/Chart.yaml
+++ b/charts/dp-config-aws/Chart.yaml
@@ -4,7 +4,7 @@
 
 apiVersion: v2
 name: dp-config-aws
-version: 1.17.1
+version: 1.17.2
 appVersion: "1.17.0"
 description: Helm chart to configure pre-requisites on AWS
 type: application

--- a/charts/dp-config-aws/charts/crossplane-components/charts/claims/templates/aurora-cluster-claim.yaml
+++ b/charts/dp-config-aws/charts/crossplane-components/charts/claims/templates/aurora-cluster-claim.yaml
@@ -77,6 +77,9 @@ spec:
         {{- range $ip := $paramValue }}
         - cidrIp: {{ $ip | quote }}
         {{- end }}
+    {{- else if (eq $paramKey "enableCloudwatchLogsExports") }}
+    enableCloudwatchLogsExports:
+      {{- toYaml $paramValue | nindent 4 }}
     {{- else if (eq $paramKey "restoreFrom") }}
     restoreFrom:
       {{- toYaml $paramValue | nindent 6 }}

--- a/charts/dp-config-aws/charts/crossplane-components/charts/claims/values.yaml
+++ b/charts/dp-config-aws/charts/crossplane-components/charts/claims/values.yaml
@@ -206,6 +206,9 @@ auroraCluster:
   #   allowedIngressConnectionsFrom:
   #     - "10.120.0.0/32"
   #     - "40.120.0.0/32"
+  #   enableCloudwatchLogsExports:
+  #     - "postgresql"
+  #     - "instance"
   #   performanceInsightsKmsKeyId: ""
   #   skipFinalSnapshot: "true"
   #   storageEncrypted: "false"

--- a/charts/dp-config-aws/charts/crossplane-components/charts/compositions/templates/aurora-postgres-cluster-composition.yaml
+++ b/charts/dp-config-aws/charts/crossplane-components/charts/compositions/templates/aurora-postgres-cluster-composition.yaml
@@ -167,6 +167,8 @@ spec:
           toFieldPath: "spec.forProvider.databaseName"
         - fromFieldPath: "spec.parameters.deletionProtection"
           toFieldPath: "spec.forProvider.deletionProtection"
+        - fromFieldPath: "spec.parameters.enableCloudwatchLogsExports"
+          toFieldPath: "spec.forProvider.enableCloudwatchLogsExports"
         - fromFieldPath: "spec.parameters.enableGlobalWriteForwarding"
           toFieldPath: "spec.forProvider.enableGlobalWriteForwarding"
         - fromFieldPath: "spec.parameters.enablePerformanceInsights"

--- a/charts/dp-config-aws/charts/crossplane-components/charts/compositions/templates/aurora-postgres-cluster-xrd.yaml
+++ b/charts/dp-config-aws/charts/crossplane-components/charts/compositions/templates/aurora-postgres-cluster-xrd.yaml
@@ -82,6 +82,10 @@ spec:
                   deletionProtection:
                     type: boolean
                     default: false
+                  enableCloudwatchLogsExports:
+                    type: array
+                    items:
+                      type: string
                   enableGlobalWriteForwarding:
                     type: boolean
                   enablePerformanceInsights:

--- a/charts/dp-config-aws/charts/crossplane-components/values.yaml
+++ b/charts/dp-config-aws/charts/crossplane-components/values.yaml
@@ -256,6 +256,9 @@ claims:
     #   allowedIngressConnectionsFrom:
     #     - "10.120.0.0/32"
     #     - "40.120.0.0/32"
+    #   enableCloudwatchLogsExports:
+    #     - "postgresql"
+    #     - "instance"
     #   performanceInsightsKmsKeyId: ""
     #   skipFinalSnapshot: "true"
     #   storageEncrypted: "false"

--- a/charts/dp-config-aws/values.yaml
+++ b/charts/dp-config-aws/values.yaml
@@ -419,6 +419,9 @@ crossplane-components:
       #   allowedIngressConnectionsFrom:
       #     - "10.120.0.0/32"
       #     - "40.120.0.0/32"
+      #   enableCloudwatchLogsExports:
+      #     - "postgresql"
+      #     - "instance"
       #   performanceInsightsKmsKeyId: ""
       #   skipFinalSnapshot: "true"
       #   storageEncrypted: "false"


### PR DESCRIPTION
This pull request adds support for configuring CloudWatch Logs exports for Aurora PostgreSQL clusters in the Helm chart. The changes introduce a new `enableCloudwatchLogsExports` parameter that can be set in claim and composition templates, as well as in the values files, allowing users to specify which logs should be exported to CloudWatch.

**Aurora PostgreSQL CloudWatch Logs Exports Support:**

* Added support for the `enableCloudwatchLogsExports` parameter in the Aurora cluster claim template, enabling users to specify log exports in their claims.
* Updated the Aurora PostgreSQL cluster composition template to map the `enableCloudwatchLogsExports` parameter from claims to the provider spec.
* Extended the Aurora PostgreSQL cluster XRD schema to include the `enableCloudwatchLogsExports` field as an array of strings.

**Documentation and Values Updates:**

* Added commented examples for the new `enableCloudwatchLogsExports` parameter in `values.yaml` files for `auroraCluster`, `claims`, and `crossplane-components` to guide users on how to configure log exports. [[1]](diffhunk://#diff-730f4e7f3593bc539cd88546821ed082dd5289dde138f117da22fc4fb466da02R209-R211) [[2]](diffhunk://#diff-2baf3d582a85aa2621a6dd6869551ccf3acaec95192c6b2ca64c04c8c20895f3R259-R261) [[3]](diffhunk://#diff-0c3c237d55f94f6da02f0f11458842e098e8073184f40545ae3afa58e30ec3dcR422-R424)

**Chart Version Update:**

* Bumped the chart version to `1.17.2` to reflect the new feature addition.