### PR TITLE
artifactmanager, dp-config-aks, dp-config-aws, dp-configure-namespace, dp-core-infrastructure, o11y-service, tp-cp-proxy & tp-dp-monitor-agent

### DIFF
--- a/charts/artifactmanager/Chart.yaml
+++ b/charts/artifactmanager/Chart.yaml
@@ -4,6 +4,6 @@
 
 apiVersion: v2
 name: artifactmanager
-version: 1.17.5
-appVersion: "1.17.0"
+version: 1.18.1
+appVersion: "1.18.0"
 description: A Helm chart for Artifact Manager

--- a/charts/artifactmanager/values.yaml
+++ b/charts/artifactmanager/values.yaml
@@ -42,7 +42,7 @@ global:
       fluentbit:
         enabled: true
         image:
-          tag: 5.0.2
+          tag: 5.0.6
         resources:
           requests:
             cpu: 10m

--- a/charts/dp-config-aks/Chart.yaml
+++ b/charts/dp-config-aks/Chart.yaml
@@ -4,8 +4,8 @@
 
 apiVersion: v2
 name: dp-config-aks
-version: 1.17.0
-appVersion: "1.17.0"
+version: 1.18.1
+appVersion: "1.18.0"
 description: A Helm chart to configure TIBCO Dataplane on AZURE
 type: application
 dependencies:
@@ -14,7 +14,7 @@ dependencies:
     repository: https://traefik.github.io/charts
     condition: traefik.enabled
   - name: ingress-nginx
-    version: 4.11.5
+    version: 4.12.1
     repository: https://kubernetes.github.io/ingress-nginx
     condition: ingress-nginx.enabled
   - name: kong
@@ -41,6 +41,11 @@ dependencies:
     version: 1.28.2
     repository: https://istio-release.storage.googleapis.com/charts
     condition: istiod.enabled
+  # netscaler cpx gateway
+  - name: netscaler-cpx-with-gateway-controller
+    version: 2.0.0
+    repository: https://netscaler.github.io/netscaler-helm-charts
+    condition: netscaler-cpx-with-gateway-controller.enabled
 annotations:
   artifacthub.io/changes: |
     - kind: changed

--- a/charts/dp-config-aks/values.yaml
+++ b/charts/dp-config-aks/values.yaml
@@ -158,6 +158,11 @@ istio-base:
 istiod:
   enabled: false
 
+# netscaler cpx gateway
+# reference: https://github.com/netscaler/netscaler-helm-charts/tree/master/netscaler-cpx-with-gateway-controller
+netscaler-cpx-with-gateway-controller:
+  enabled: false
+
 global:
   dnsSandboxSubdomain: ""
   dnsGlobalTopDomain: ""

--- a/charts/dp-config-aws/Chart.yaml
+++ b/charts/dp-config-aws/Chart.yaml
@@ -4,8 +4,8 @@
 
 apiVersion: v2
 name: dp-config-aws
-version: 1.17.2
-appVersion: "1.17.0"
+version: 1.18.1
+appVersion: "1.18.0"
 description: Helm chart to configure pre-requisites on AWS
 type: application
 dependencies:
@@ -47,9 +47,14 @@ dependencies:
     repository: https://charts.crossplane.io/stable
     condition: crossplane.enabled
   - name: crossplane-components
-    version: "1.17.*"
+    version: "1.18.*"
     repository: file://charts/crossplane-components
     condition: crossplane-components.enabled
+  # netscaler cpx gateway
+  - name: netscaler-cpx-with-gateway-controller
+    version: 2.0.0
+    repository: https://netscaler.github.io/netscaler-helm-charts
+    condition: netscaler-cpx-with-gateway-controller.enabled
 annotations:
   artifacthub.io/changes: |
     - kind: changed

--- a/charts/dp-config-aws/charts/crossplane-components/Chart.yaml
+++ b/charts/dp-config-aws/charts/crossplane-components/Chart.yaml
@@ -4,8 +4,8 @@
 
 apiVersion: v2
 name: crossplane-components
-version: 1.17.1
-appVersion: "1.17.0"
+version: 1.18.0
+appVersion: "1.18.0"
 description: crossplane-charts are used to install crossplane, providers, provider-configs, compositions and claims
 type: application
 dependencies:
@@ -19,11 +19,11 @@ dependencies:
     repository: file://charts/configs
     condition: configs.enabled
   - name: compositions
-    version: "1.17.*"
+    version: "1.18.*"
     repository: file://charts/compositions
     condition: compositions.enabled
   - name: claims
-    version: "1.17.*"
+    version: "1.18.*"
     repository: file://charts/claims
     condition: claims.enabled
 annotations:

--- a/charts/dp-config-aws/charts/crossplane-components/charts/claims/Chart.yaml
+++ b/charts/dp-config-aws/charts/crossplane-components/charts/claims/Chart.yaml
@@ -6,8 +6,8 @@ apiVersion: v2
 name: claims
 description: TIBCO Platform Control Plane crossplane claims chart
 type: application
-version: 1.17.0
-appVersion: "1.17.0"
+version: 1.18.0
+appVersion: "1.18.0"
 annotations:
   app.helm.sh/component: control-plane
   app.helm.sh/name: claims

--- a/charts/dp-config-aws/charts/crossplane-components/charts/compositions/Chart.yaml
+++ b/charts/dp-config-aws/charts/crossplane-components/charts/compositions/Chart.yaml
@@ -6,8 +6,8 @@ apiVersion: v2
 name: compositions
 description: TIBCO Platform Control Plane crossplane composite resource definitions and compositions chart
 type: application
-version: 1.17.0
-appVersion: "1.17.0"
+version: 1.18.0
+appVersion: "1.18.0"
 annotations:
   app.helm.sh/component: control-plane
   app.helm.sh/name: compositions

--- a/charts/dp-config-aws/values.yaml
+++ b/charts/dp-config-aws/values.yaml
@@ -163,6 +163,11 @@ istio-base:
 istiod:
   enabled: false
 
+# netscaler cpx gateway
+# reference: https://github.com/netscaler/netscaler-helm-charts/tree/master/netscaler-cpx-with-gateway-controller
+netscaler-cpx-with-gateway-controller:
+  enabled: false
+
 # reference: https://docs.crossplane.io/latest/software/install/
 # this is used for deploying crossplane chart
 crossplane:

--- a/charts/dp-configure-namespace/Chart.yaml
+++ b/charts/dp-configure-namespace/Chart.yaml
@@ -6,8 +6,8 @@ apiVersion: v2
 name: dp-configure-namespace
 description: A Helm chart for creating service account, cluster-role, cluster-role-binding, role-binding & network-policies
 type: application
-version: 1.17.1
-appVersion: "1.17.0"
+version: 1.18.3
+appVersion: "1.18.0"
 dependencies:
 - condition: config.enabled
   name: config
@@ -16,4 +16,4 @@ dependencies:
 - condition: haproxy.enabled
   name: haproxy
   repository: ""
-  version: 1.46.3
+  version: 1.52.0

--- a/charts/dp-configure-namespace/charts/haproxy/Chart.yaml
+++ b/charts/dp-configure-namespace/charts/haproxy/Chart.yaml
@@ -5,7 +5,7 @@ annotations:
     - Add helm hook annotations to crdjob (#312)
     - Make initContainers templateable (#311)
 apiVersion: v2
-appVersion: 3.1.17
+appVersion: 3.2.9
 description: A Helm chart for HAProxy Kubernetes Ingress Controller
 home: https://github.com/haproxytech/helm-charts/tree/main/kubernetes-ingress
 icon: https://raw.githubusercontent.com/haproxytech/helm-charts/main/kubernetes-ingress/chart-icon.png
@@ -20,4 +20,4 @@ name: haproxy
 sources:
 - https://github.com/haproxytech/kubernetes-ingress
 type: application
-version: 1.46.3
+version: 1.52.0

--- a/charts/dp-configure-namespace/charts/haproxy/values.yaml
+++ b/charts/dp-configure-namespace/charts/haproxy/values.yaml
@@ -219,10 +219,10 @@ controller:
   resources:
     limits:
       cpu: 500m
-      memory: 512Mi
+      memory: 1024Mi
     requests:
-      cpu: 100m
-      memory: 256Mi
+      cpu: 250m
+      memory: 512Mi
 
   ## Horizontal Pod Scaler
   ## Only to be used with Deployment kind

--- a/charts/dp-configure-namespace/templates/ha-proxy-role.yaml
+++ b/charts/dp-configure-namespace/templates/ha-proxy-role.yaml
@@ -83,6 +83,18 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ingress.v1.haproxy.org
+  - ingress.v1.haproxy.com
+  - ingress.v3.haproxy.org
+  - ingress.v3.haproxy.com
+  resources:
+  - "*"
+  verbs:
+  - get
+  - list
+  - watch
+  - update
 
 ---
 

--- a/charts/dp-configure-namespace/values.yaml
+++ b/charts/dp-configure-namespace/values.yaml
@@ -194,6 +194,7 @@ haproxy:
     ingressClass: tibco-dp-{{ .Values.global.tibco.dataPlaneId }}
     extraArgs:
     - --namespace-whitelist={{ .Release.Namespace }}
+    - --disable-ipv6
     service:
       type: ClusterIP
       enabled: true

--- a/charts/dp-core-infrastructure/Chart.yaml
+++ b/charts/dp-core-infrastructure/Chart.yaml
@@ -3,17 +3,17 @@
 # in the license file that is distributed with this file.
 
 apiVersion: v2
-appVersion: "1.17.0"
+appVersion: "1.18.0"
 dependencies:
 - condition: global.tibco.hybridConnectivity.enabled
   name: tp-tibtunnel
   repository: ""
-  version: 1.17.*
+  version: 1.18.*
 - condition: tp-provisioner-agent.enabled
   name: tp-provisioner-agent
   repository: ""
-  version: 1.17.*
+  version: 1.18.*
 description: A Helm chart for Data Plane Infrastructure
 name: dp-core-infrastructure
 type: application
-version: 1.17.6
+version: 1.18.4

--- a/charts/dp-core-infrastructure/charts/tp-provisioner-agent/Chart.yaml
+++ b/charts/dp-core-infrastructure/charts/tp-provisioner-agent/Chart.yaml
@@ -3,11 +3,11 @@
 # in the license file that is distributed with this file.
 
 apiVersion: v2
-appVersion: "1.17.0"
+appVersion: "1.18.0"
 description: A Helm chart for TIBCO Provisioner Agent
 keywords:
 - provisioner-agent
 - data-plane
 name: tp-provisioner-agent
-version: 1.17.0
+version: 1.18.0
 

--- a/charts/dp-core-infrastructure/charts/tp-provisioner-agent/values.yaml
+++ b/charts/dp-core-infrastructure/charts/tp-provisioner-agent/values.yaml
@@ -26,7 +26,7 @@ cacheCleanupInterval: "8h"
 
 image:
   name: infra-provisioner-agent
-  tag: 680
+  tag: 698
   pullPolicy: Always
 
 nodeSelector:

--- a/charts/dp-core-infrastructure/charts/tp-tibtunnel/Chart.yaml
+++ b/charts/dp-core-infrastructure/charts/tp-tibtunnel/Chart.yaml
@@ -3,12 +3,12 @@
 # in the license file that is distributed with this file.
 
 apiVersion: v1
-appVersion: "1.17.0"
+appVersion: "1.18.0"
 description: A Helm chart for TIBCO Tibtunnel
 keywords:
 - tibtunnel
 - data-plane
 - hybrid-connectivity
 name: tp-tibtunnel
-version: 1.17.0
+version: 1.18.0
 

--- a/charts/dp-core-infrastructure/charts/tp-tibtunnel/values.yaml
+++ b/charts/dp-core-infrastructure/charts/tp-tibtunnel/values.yaml
@@ -52,7 +52,7 @@ replicaCount: "1"
 image:
   name: infra-tibtunnel
   pullPolicy: IfNotPresent
-  tag: 232
+  tag: 240
 
 nodeSelector:
   kubernetes.io/os: linux

--- a/charts/dp-core-infrastructure/values.yaml
+++ b/charts/dp-core-infrastructure/values.yaml
@@ -59,7 +59,7 @@ tp-tibtunnel:
     logFile: ""  # Full path to the output log file. If not specified, the logs will be printed on stdout
     configDir: ""  # Full path to the directory where to store the configuration file(s) (default "~/.tibtunnel")
     networkCheckUrl: ""  # Url to check for network connectivity
-    infiniteRetries: false  # Irrespective of any error, keep trying to discover and connect to establish hybrid connectivity
+    infiniteRetries: true  # Irrespective of any error, keep trying to discover and connect to establish hybrid connectivity
     url: ""  # Connect Url generated from TIBCO Cloud Control plane
     onPremHost: "cpdpproxy"  # service name of on prem host
     onPremPort: "80"  # port number of the service.

--- a/charts/o11y-service/Chart.yaml
+++ b/charts/o11y-service/Chart.yaml
@@ -4,6 +4,6 @@
 
 apiVersion: v2
 name: o11yservice
-version: 1.17.16
-appVersion: "1.17.0"
+version: 1.18.13
+appVersion: "1.18.0"
 description: A helm chart for o11y service

--- a/charts/o11y-service/templates/configmap.yaml
+++ b/charts/o11y-service/templates/configmap.yaml
@@ -13,6 +13,7 @@ metadata:
     {{- include "o11y-service.labels" . | nindent 4 }}
   name: {{ include "o11y-service.fullname" . }}
 data:
+  clusterRolePerm: {{ .Values.global.cp.enableClusterScopedPerm | quote}}
   otel-recvservice-name: {{ .Values.global.cp.resources.o11y.config.otel.receiver.service.name }}
   otel-recvservice-port: {{ quote .Values.global.cp.resources.o11y.config.otel.receiver.service.port }}
   otel-recv-logs-name: {{ .Values.global.cp.resources.o11y.config.otel.receiver.logs.name }}

--- a/charts/o11y-service/templates/ingress-baremetal.yaml
+++ b/charts/o11y-service/templates/ingress-baremetal.yaml
@@ -16,7 +16,7 @@
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: bm-{{ .Values.global.cp.resources.ingress.ingressClassName }}-logs-rewrite
+  name: bm-logs-rewrite
   namespace: {{ .Values.global.cp.resources.serviceaccount.namespace | default .Release.Namespace }}
 spec:
   # Static rewrite to /v1/logs (equivalent to nginx rewrite-target: /v1/logs)
@@ -25,11 +25,48 @@ spec:
     regex: ^/tibco/agent/o11y/{{ $.Values.global.cp.dataplaneId }}/logs
 ---
 {{- end }}
-{{- if eq .Values.global.cp.resources.ingress.ingressController "openshiftRouter" }}
+{{- if not (empty .Values.global.cp.resources.gatewayapi.gatewayAPIControllerName) }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: bm-logs
+  namespace: {{ .Values.global.cp.resources.serviceaccount.namespace | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: load-balancer
+    {{- include "o11y-service.labels" . | nindent 4 }}
+  annotations:
+    platform.tibco.com/controller-name: {{ .Values.global.cp.resources.gatewayapi.gatewayAPIControllerName | quote }}
+spec:
+  parentRefs:
+  - name: {{ .Values.global.cp.resources.gatewayapi.gatewayName }}
+    {{- if .Values.global.cp.resources.gatewayapi.gatewayNamespace }}
+    namespace: {{ .Values.global.cp.resources.gatewayapi.gatewayNamespace }}
+    {{- end }}
+    {{- if .Values.global.cp.resources.gatewayapi.gatewaySectionName }}
+    sectionName: {{ .Values.global.cp.resources.gatewayapi.gatewaySectionName }}
+    {{- end }}
+  hostnames:
+  - {{ .Values.global.cp.resources.gatewayapi.gatewayHostOrDomainName | quote }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /tibco/agent/o11y/{{ $.Values.global.cp.dataplaneId }}/logs
+    backendRefs:
+    - name: otel-userapp-logs
+      port: 4318
+    filters:
+    - type: URLRewrite
+      urlRewrite:
+        path:
+          type: ReplacePrefixMatch
+          replacePrefixMatch: /v1/logs
+---
+{{- else if eq .Values.global.cp.resources.ingress.ingressController "openshiftRouter" }}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: bm-openshift-route-logs
+  name: bm-logs
   labels:
     app.kubernetes.io/component: load-balancer
     {{- include "o11y-service.labels" . | nindent 4 }}
@@ -65,7 +102,7 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: bm-{{ .Values.global.cp.resources.ingress.ingressClassName }}-logs
+  name: bm-logs
   labels:
     app.kubernetes.io/component: load-balancer
     {{- include "o11y-service.labels" . | nindent 4 }}
@@ -76,8 +113,14 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /v1/logs
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
-    {{- end }}
-    {{- if eq .Values.global.cp.resources.ingress.ingressController "traefik" }}
+    {{- else if eq .Values.global.cp.resources.ingress.ingressController "haproxy" }}
+    haproxy.org/request-set-header: |
+      X-Forwarded-Host %[req.hdr(host)]
+      X-Forwarded-Port 443
+      X-Forwarded-Proto https
+      X-Forwarded-Prefix /tibco/agent/o11y/{{ $.Values.global.cp.dataplaneId }}/logs
+    haproxy.org/path-rewrite: /tibco/agent/o11y/{{ $.Values.global.cp.dataplaneId }}/logs/(.*) /\1
+    {{- else if eq .Values.global.cp.resources.ingress.ingressController "traefik" }}
     traefik.ingress.kubernetes.io/router.middlewares: {{ .Values.global.cp.resources.serviceaccount.namespace }}-bm-{{ .Values.global.cp.resources.ingress.ingressClassName }}-logs-rewrite@kubernetescrd
     {{- end }}
 spec:
@@ -123,7 +166,7 @@ spec:
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: bm-{{ .Values.global.cp.resources.ingress.ingressClassName }}-traces-rewrite
+  name: bm-traces-rewrite
   namespace: {{ .Values.global.cp.resources.serviceaccount.namespace | default .Release.Namespace }}
 spec:
   # Static rewrite to /v1/traces (equivalent to nginx rewrite-target: /v1/traces)
@@ -132,11 +175,48 @@ spec:
     regex: ^/tibco/agent/o11y/{{ $.Values.global.cp.dataplaneId }}/traces
 ---
 {{- end }}
-{{- if eq .Values.global.cp.resources.ingress.ingressController "openshiftRouter" }}
+{{- if not (empty .Values.global.cp.resources.gatewayapi.gatewayAPIControllerName) }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: bm-traces
+  namespace: {{ .Values.global.cp.resources.serviceaccount.namespace | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: load-balancer
+    {{- include "o11y-service.labels" . | nindent 4 }}
+  annotations:
+    platform.tibco.com/controller-name: {{ .Values.global.cp.resources.gatewayapi.gatewayAPIControllerName | quote }}
+spec:
+  parentRefs:
+  - name: {{ .Values.global.cp.resources.gatewayapi.gatewayName }}
+    {{- if .Values.global.cp.resources.gatewayapi.gatewayNamespace }}
+    namespace: {{ .Values.global.cp.resources.gatewayapi.gatewayNamespace }}
+    {{- end }}
+    {{- if .Values.global.cp.resources.gatewayapi.gatewaySectionName }}
+    sectionName: {{ .Values.global.cp.resources.gatewayapi.gatewaySectionName }}
+    {{- end }}
+  hostnames:
+  - {{ .Values.global.cp.resources.gatewayapi.gatewayHostOrDomainName | quote }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /tibco/agent/o11y/{{ $.Values.global.cp.dataplaneId }}/traces
+    backendRefs:
+    - name: otel-userapp-traces
+      port: 4318
+    filters:
+    - type: URLRewrite
+      urlRewrite:
+        path:
+          type: ReplacePrefixMatch
+          replacePrefixMatch: /v1/traces
+---
+{{- else if eq .Values.global.cp.resources.ingress.ingressController "openshiftRouter" }}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: bm-openshift-route-traces
+  name: bm-traces
   labels:
     app.kubernetes.io/component: load-balancer
     {{- include "o11y-service.labels" . | nindent 4 }}
@@ -172,20 +252,26 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: bm-{{ .Values.global.cp.resources.ingress.ingressClassName }}-traces
+  name: bm-traces
   labels:
     app.kubernetes.io/component: load-balancer
     {{- include "o11y-service.labels" . | nindent 4 }}
   annotations:
     meta.helm.sh/release-namespace: {{ .Values.global.cp.resources.serviceaccount.namespace }}
     meta.helm.sh/release-name: {{ $fullName }}
-    {{- if eq .Values.global.cp.resources.ingress.ingressController "traefik" }}
-    traefik.ingress.kubernetes.io/router.middlewares: {{ .Values.global.cp.resources.serviceaccount.namespace }}-bm-{{ .Values.global.cp.resources.ingress.ingressClassName }}-traces-rewrite@kubernetescrd
-    {{- end }}
     {{- if eq .Values.global.cp.resources.ingress.ingressController "nginx" }}
     nginx.ingress.kubernetes.io/rewrite-target: /v1/traces
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    {{- else if eq .Values.global.cp.resources.ingress.ingressController "haproxy" }}
+    haproxy.org/request-set-header: |
+      X-Forwarded-Host %[req.hdr(host)]
+      X-Forwarded-Port 443
+      X-Forwarded-Proto https
+      X-Forwarded-Prefix /tibco/agent/o11y/{{ $.Values.global.cp.dataplaneId }}/traces
+    haproxy.org/path-rewrite: /tibco/agent/o11y/{{ $.Values.global.cp.dataplaneId }}/traces/(.*) /\1
+    {{- else if eq .Values.global.cp.resources.ingress.ingressController "traefik" }}
+    traefik.ingress.kubernetes.io/router.middlewares: {{ .Values.global.cp.resources.serviceaccount.namespace }}-bm-{{ .Values.global.cp.resources.ingress.ingressClassName }}-traces-rewrite@kubernetescrd
     {{- end }}
 spec:
   {{- if and .Values.global.cp.dataplane.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
@@ -230,7 +316,7 @@ spec:
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: bm-{{ .Values.global.cp.resources.ingress.ingressClassName }}-metrics-rewrite
+  name: bm-metrics-rewrite
   namespace: {{ .Values.global.cp.resources.serviceaccount.namespace | default .Release.Namespace }}
 spec:
   # Static rewrite to /v1/metrics (equivalent to nginx rewrite-target: /v1/metrics)
@@ -239,11 +325,48 @@ spec:
     regex: ^/tibco/agent/o11y/{{ $.Values.global.cp.dataplaneId }}/metrics
 ---
 {{- end }}
-{{- if eq .Values.global.cp.resources.ingress.ingressController "openshiftRouter" }}
+{{- if not (empty .Values.global.cp.resources.gatewayapi.gatewayAPIControllerName) }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: bm-metrics
+  namespace: {{ .Values.global.cp.resources.serviceaccount.namespace | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: load-balancer
+    {{- include "o11y-service.labels" . | nindent 4 }}
+  annotations:
+    platform.tibco.com/controller-name: {{ .Values.global.cp.resources.gatewayapi.gatewayAPIControllerName | quote }}
+spec:
+  parentRefs:
+  - name: {{ .Values.global.cp.resources.gatewayapi.gatewayName }}
+    {{- if .Values.global.cp.resources.gatewayapi.gatewayNamespace }}
+    namespace: {{ .Values.global.cp.resources.gatewayapi.gatewayNamespace }}
+    {{- end }}
+    {{- if .Values.global.cp.resources.gatewayapi.gatewaySectionName }}
+    sectionName: {{ .Values.global.cp.resources.gatewayapi.gatewaySectionName }}
+    {{- end }}
+  hostnames:
+  - {{ .Values.global.cp.resources.gatewayapi.gatewayHostOrDomainName | quote }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /tibco/agent/o11y/{{ $.Values.global.cp.dataplaneId }}/metrics
+    backendRefs:
+    - name: otel-userapp-metrics
+      port: 4318
+    filters:
+    - type: URLRewrite
+      urlRewrite:
+        path:
+          type: ReplacePrefixMatch
+          replacePrefixMatch: /v1/metrics
+---
+{{- else if eq .Values.global.cp.resources.ingress.ingressController "openshiftRouter" }}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: bm-openshift-route-metrics
+  name: bm-metrics
   labels:
     app.kubernetes.io/component: load-balancer
     {{- include "o11y-service.labels" . | nindent 4 }}
@@ -279,20 +402,26 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: bm-{{ .Values.global.cp.resources.ingress.ingressClassName }}-metrics
+  name: bm-metrics
   labels:
     app.kubernetes.io/component: load-balancer
     {{- include "o11y-service.labels" . | nindent 4 }}
   annotations:
     meta.helm.sh/release-namespace: {{ .Values.global.cp.resources.serviceaccount.namespace }}
     meta.helm.sh/release-name: {{ $fullName }}
-    {{- if eq .Values.global.cp.resources.ingress.ingressController "traefik" }}
-    traefik.ingress.kubernetes.io/router.middlewares: {{ .Values.global.cp.resources.serviceaccount.namespace }}-bm-{{ .Values.global.cp.resources.ingress.ingressClassName }}-metrics-rewrite@kubernetescrd
-    {{- end }}
     {{- if eq .Values.global.cp.resources.ingress.ingressController "nginx" }}
     nginx.ingress.kubernetes.io/rewrite-target: /v1/metrics
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    {{- else if eq .Values.global.cp.resources.ingress.ingressController "haproxy" }}
+    haproxy.org/request-set-header: |
+      X-Forwarded-Host %[req.hdr(host)]
+      X-Forwarded-Port 443
+      X-Forwarded-Proto https
+      X-Forwarded-Prefix /tibco/agent/o11y/{{ $.Values.global.cp.dataplaneId }}/metrics
+    haproxy.org/path-rewrite: /tibco/agent/o11y/{{ $.Values.global.cp.dataplaneId }}/metrics/(.*) /\1
+    {{- else if eq .Values.global.cp.resources.ingress.ingressController "traefik" }}
+    traefik.ingress.kubernetes.io/router.middlewares: {{ .Values.global.cp.resources.serviceaccount.namespace }}-bm-{{ .Values.global.cp.resources.ingress.ingressClassName }}-metrics-rewrite@kubernetescrd
     {{- end }}
 spec:
   {{- if and .Values.global.cp.dataplane.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
@@ -346,11 +475,48 @@ spec:
     regex: ^/tibco/agent/o11y/{{ $.Values.global.cp.dataplaneId }}/metrics
 ---
 {{- end }}
-{{- if eq .Values.global.cp.resources.ingress.ingressController "openshiftRouter" }}
+{{- if not (empty .Values.global.cp.resources.gatewayapi.gatewayAPIControllerName) }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: bm-metrics-export
+  namespace: {{ .Values.global.cp.resources.serviceaccount.namespace | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: load-balancer
+    {{- include "o11y-service.labels" . | nindent 4 }}
+  annotations:
+    platform.tibco.com/controller-name: {{ .Values.global.cp.resources.gatewayapi.gatewayAPIControllerName | quote }}
+spec:
+  parentRefs:
+  - name: {{ .Values.global.cp.resources.gatewayapi.gatewayName }}
+    {{- if .Values.global.cp.resources.gatewayapi.gatewayNamespace }}
+    namespace: {{ .Values.global.cp.resources.gatewayapi.gatewayNamespace }}
+    {{- end }}
+    {{- if .Values.global.cp.resources.gatewayapi.gatewaySectionName }}
+    sectionName: {{ .Values.global.cp.resources.gatewayapi.gatewaySectionName }}
+    {{- end }}
+  hostnames:
+  - {{ .Values.global.cp.resources.gatewayapi.gatewayHostOrDomainName | quote }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /tibco/agent/o11y/{{ $.Values.global.cp.dataplaneId }}/exporter/metrics
+    backendRefs:
+    - name: otel-userapp-metrics
+      port: 4319
+    filters:
+    - type: URLRewrite
+      urlRewrite:
+        path:
+          type: ReplacePrefixMatch
+          replacePrefixMatch: /metrics
+---
+{{- else if eq .Values.global.cp.resources.ingress.ingressController "openshiftRouter" }}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: bm-openshift-route-metrics-export
+  name: bm-metrics-export
   labels:
     app.kubernetes.io/component: load-balancer
     {{- include "o11y-service.labels" . | nindent 4 }}
@@ -386,20 +552,26 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: bm-{{ .Values.global.cp.resources.ingress.ingressClassName }}-metrics-export
+  name: bm-metrics-export
   labels:
     app.kubernetes.io/component: load-balancer
     {{- include "o11y-service.labels" . | nindent 4 }}
   annotations:
     meta.helm.sh/release-namespace: {{ .Values.global.cp.resources.serviceaccount.namespace }}
     meta.helm.sh/release-name: {{ $fullName }}
-    {{- if eq .Values.global.cp.resources.ingress.ingressController "traefik" }}
-    traefik.ingress.kubernetes.io/router.middlewares: {{ .Values.global.cp.resources.serviceaccount.namespace }}-bm-{{ .Values.global.cp.resources.ingress.ingressClassName }}-metrics-export-rewrite@kubernetescrd
-    {{- end }}
     {{- if eq .Values.global.cp.resources.ingress.ingressController "nginx" }}
     nginx.ingress.kubernetes.io/rewrite-target: /metrics
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    {{- else if eq .Values.global.cp.resources.ingress.ingressController "haproxy" }}
+    haproxy.org/request-set-header: |
+      X-Forwarded-Host %[req.hdr(host)]
+      X-Forwarded-Port 443
+      X-Forwarded-Proto https
+      X-Forwarded-Prefix /tibco/agent/o11y/{{ $.Values.global.cp.dataplaneId }}/exporter/metrics
+    haproxy.org/path-rewrite: /tibco/agent/o11y/{{ $.Values.global.cp.dataplaneId }}/exporter/metrics/(.*) /\1
+    {{- else if eq .Values.global.cp.resources.ingress.ingressController "traefik" }}
+    traefik.ingress.kubernetes.io/router.middlewares: {{ .Values.global.cp.resources.serviceaccount.namespace }}-bm-{{ .Values.global.cp.resources.ingress.ingressClassName }}-metrics-export-rewrite@kubernetescrd
     {{- end }}
 spec:
   {{- if and .Values.global.cp.dataplane.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}

--- a/charts/o11y-service/values.yaml
+++ b/charts/o11y-service/values.yaml
@@ -450,6 +450,13 @@ global:
         fqdn: ""
         ingressClassName: "my-nginx-ingress"
         ingressController: "nginx"
+      # Gateway API configuration - used when ingressController is set to "gateway"
+      gatewayapi:
+        gatewayAPIControllerName: ""  # valid values are GKE/nginx
+        gatewayName: ""
+        gatewayNamespace: ""
+        gatewayHostOrDomainName: ""
+        gatewaySectionName: ""  # This is optional
 
     logging:
       # The fluentbit configuration section.
@@ -461,7 +468,7 @@ global:
         enabled: true
         image:
           name: "common-fluentbit"
-          tag: 5.0.2
+          tag: 5.0.6
         resources:
           requests:
             cpu: 10m
@@ -480,10 +487,10 @@ global:
       namespace: dp-integration-default
     image:
       registry: 664529841144.dkr.ecr.us-west-2.amazonaws.com
-      tag: 4207
+      tag: 4723
     job:
       image:
-        tag: 9328
+        tag: 9474
 
 
 replicaCount: 1

--- a/charts/tp-cp-proxy/Chart.yaml
+++ b/charts/tp-cp-proxy/Chart.yaml
@@ -3,10 +3,10 @@
 # in the license file that is distributed with this file.
 
 apiVersion: v2
-appVersion: 1.17.0
+appVersion: 1.18.0
 description: A Helm chart for Control Plane Proxy
 keywords:
 - cp-proxy
 - data-plane
 name: tp-cp-proxy
-version: 1.17.4
+version: 1.18.0

--- a/charts/tp-cp-proxy/values.yaml
+++ b/charts/tp-cp-proxy/values.yaml
@@ -27,7 +27,7 @@ replicaCount: "1"
 
 image:
   name: infra-cp-proxy
-  tag: 311
+  tag: 323
   pullPolicy: IfNotPresent
 
 nodeSelector:

--- a/charts/tp-dp-monitor-agent/Chart.yaml
+++ b/charts/tp-dp-monitor-agent/Chart.yaml
@@ -3,7 +3,7 @@
 # in the license file that is distributed with this file.
 
 apiVersion: v2
-appVersion: 1.17.0
+appVersion: 1.18.0
 description: A Helm chart for deploying the tp-dp-monitor-agent service
 name: tp-dp-monitor-agent
-version: 1.17.13
+version: 1.18.9

--- a/charts/tp-dp-monitor-agent/templates/_generated.tpl
+++ b/charts/tp-dp-monitor-agent/templates/_generated.tpl
@@ -4,5 +4,5 @@
   in the license file that is distributed with this file.
 */}}
 
-{{- define "tp-dp-monitor-agent.generated.buildNumber" }}385{{end -}}
+{{- define "tp-dp-monitor-agent.generated.buildNumber" }}403{{end -}}
 {{- define "tp-dp-monitor-agent.generated.buildTimestamp" }}06-26-25_06.30.00_PM{{end -}}

--- a/charts/tp-dp-monitor-agent/values.yaml
+++ b/charts/tp-dp-monitor-agent/values.yaml
@@ -10,7 +10,7 @@ global:
       fluentbit:
         image:
           name: "common-fluentbit"
-          tag: 5.0.2
+          tag: latest
   cp:
     dataplaneId: "abcd"
     subscriptionId: "sub1"


### PR DESCRIPTION
This pull request updates multiple Helm charts to version 1.18.x, introduces support for the Netscaler CPX Gateway, and enhances ingress and routing configurations for the o11y-service chart. The changes ensure compatibility with newer dependencies, add flexibility for different ingress controllers, and improve observability routing.

**Version Upgrades and Dependency Updates:**

* All major Helm charts (`artifactmanager`, `dp-config-aks`, `dp-config-aws`, `dp-core-infrastructure`, `o11y-service`, and their subcharts) are updated to version 1.18.x for both `version` and `appVersion`, ensuring consistency and compatibility across the stack. [[1]](diffhunk://#diff-4eb01d9be367c9cb5797de7566b26425171795fcf0680ca93a7fa113628c8c36L7-R8) [[2]](diffhunk://#diff-4b7f21a2ac18e355a837e126b061b373f583c828ca778b1350030003ba86f925L7-R8) [[3]](diffhunk://#diff-6b7d6b0bf76c2017b2249fd392c3e6d1bb444700a14fccf591e1e4c499a4e901L7-R8) [[4]](diffhunk://#diff-3a7d6502c3e55ce31f3c077c65685afc5d69289887a1552831b89481b2d63631L6-R19) [[5]](diffhunk://#diff-caabbcdf963d65e8d87b3bb698ec387b9c01cf35782af431b106213d42cb7bd8L7-R8) [[6]](diffhunk://#diff-c320779730b25284828763477de2e4f73c76c1f8d08f79eec5cb66b676509604L7-R8) [[7]](diffhunk://#diff-ce069f48b5ce442f236d7521c30e8e9789cdcba18eccaf45b20c8e0f9c8829dbL6-R13) F6518513L4R4, [[8]](diffhunk://#diff-790ce390cd57f822f89312cefa9abbf2930a219cccf6fbf91d2d362fa77aa1eaL9-R10) [[9]](diffhunk://#diff-d0301b07bafda2943d07a40040037206957ff62a171ec75be364082104dc6555L9-R10)
* Dependency versions for `ingress-nginx`, `crossplane-components`, `compositions`, and `claims` are updated to their respective 1.18.x or latest minor versions. [[1]](diffhunk://#diff-4b7f21a2ac18e355a837e126b061b373f583c828ca778b1350030003ba86f925L17-R17) [[2]](diffhunk://#diff-6b7d6b0bf76c2017b2249fd392c3e6d1bb444700a14fccf591e1e4c499a4e901L50-R57) [[3]](diffhunk://#diff-c320779730b25284828763477de2e4f73c76c1f8d08f79eec5cb66b676509604L22-R26)

**Ingress and Routing Enhancements (o11y-service):**

* Adds support for Gateway API (`HTTPRoute`) for logs and traces endpoints, in addition to existing ingress controllers (Nginx, Traefik, HAProxy, OpenShift), improving flexibility in routing and supporting modern Kubernetes networking. [[1]](diffhunk://#diff-6956dd7945418d0503554dd421670138f4569db4d00732ef1a5ba7b9e97bf30dL28-R69) [[2]](diffhunk://#diff-6956dd7945418d0503554dd421670138f4569db4d00732ef1a5ba7b9e97bf30dL135-R219)
* Adds HAProxy-specific annotations for path and header rewrites, and standardizes resource naming for ingress and middleware objects. [[1]](diffhunk://#diff-6956dd7945418d0503554dd421670138f4569db4d00732ef1a5ba7b9e97bf30dL79-R123) [[2]](diffhunk://#diff-6956dd7945418d0503554dd421670138f4569db4d00732ef1a5ba7b9e97bf30dL126-R169) [[3]](diffhunk://#diff-6956dd7945418d0503554dd421670138f4569db4d00732ef1a5ba7b9e97bf30dL233-R319)
* Adds a new `clusterRolePerm` field to the o11y-service configmap for improved permission management.

**Netscaler CPX Gateway Integration:**

* Adds the `netscaler-cpx-with-gateway-controller` chart as an optional dependency in both `dp-config-aks` and `dp-config-aws`, with corresponding values to enable or disable it. This enables deployment of the Netscaler CPX Gateway if desired. [[1]](diffhunk://#diff-4b7f21a2ac18e355a837e126b061b373f583c828ca778b1350030003ba86f925R44-R48) [[2]](diffhunk://#diff-bd7c685e763973ad224c05b3c07c5a86e04bc5033f083d3607dc02671b2e7a12R161-R165) [[3]](diffhunk://#diff-6b7d6b0bf76c2017b2249fd392c3e6d1bb444700a14fccf591e1e4c499a4e901L50-R57) [[4]](diffhunk://#diff-0c3c237d55f94f6da02f0f11458842e098e8073184f40545ae3afa58e30ec3dcR166-R170)

**Image and Configuration Updates:**

* Updates container image tags for `infra-provisioner-agent` (from 680 to 698), `infra-tibtunnel` (from 232 to 240), and `fluentbit` (from 5.0.2 to 5.0.6) to pull newer images with potential bug fixes and features. [[1]](diffhunk://#diff-e7865f7a50b54eef6d0885d86ef8572c4c0b786ac8a4c6b957e7f230b98527f0L29-R29) [[2]](diffhunk://#diff-bcd04c856b1e609b3fef19df20a9483a9f4414708723f2ce3d9159305988dbd1L55-R55) [[3]](diffhunk://#diff-94d15c5844682875c61ddbe6128e4459af584bab8f914c6d006ce17af3b29fb8L45-R45)
* Changes the default `infiniteRetries` setting in `tp-tibtunnel` to `true` for more resilient hybrid connectivity.

These updates collectively modernize the deployment stack, improve ingress flexibility, and add support for new networking components.