### PR TITLE
Updated Tibco Developer Hub 1.18.0 Charts in public repo with GA tag

### DIFF
--- a/artifacts/developer-hub/developer-hub-1.18.0-charts.txt
+++ b/artifacts/developer-hub/developer-hub-1.18.0-charts.txt
@@ -1,4 +1,4 @@
-tibco-cp-devhub:1.18.0-alpha.13
+tibco-cp-devhub:1.18.0
 tibco-developer-hub:1.18.12
 tibcohub-contrib:1.18.0
 tibcohub-recipes:1.18.0

--- a/charts/tibco-cp-devhub/Chart.yaml
+++ b/charts/tibco-cp-devhub/Chart.yaml
@@ -5,7 +5,7 @@
 #
 apiVersion: v2
 name: tibco-cp-devhub
-version: 1.18.0-alpha.13
+version: 1.18.0
 appVersion: 1.18.0
 description: TIBCO Platform base for Developer Hub Capability
 dependencies:


### PR DESCRIPTION
Updated Tibco Developer Hub 1.18.0 Charts in public repo with GA tag