### PR TITLE
wip/PCP-19827: workflow for GA release automation

### DIFF
--- a/.github/workflows/promote-ga-charts.yaml
+++ b/.github/workflows/promote-ga-charts.yaml
@@ -18,6 +18,7 @@ on:
           - tibco-cp-bw
           - tibco-cp-flogo
           - tibco-cp-devhub
+          - tibco-cp-addon-eventprocessing
       pr:
         description: 'PR number or full PR link (e.g. 123 or https://github.com/TIBCOSoftware/tp-helm-charts/pull/123)'
         required: true
@@ -69,7 +70,9 @@ jobs:
           repositories: tp-helm-charts
 
       - name: Export App token to GH_TOKEN
-        run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
+        env:
+          TOKEN: ${{ steps.app-token.outputs.token }}
+        run: echo "GH_TOKEN=$TOKEN" >> $GITHUB_ENV
 
       # ── Record start time ────────────────────────────────────────────────
       # Captured immediately after the authorization gate so the audit summary
@@ -200,13 +203,6 @@ jobs:
           fi
 
           STABLE="${BASH_REMATCH[1]}"
-          echo "Target stable (GA) version: $STABLE"
-
-          # Validate derived stable version
-          if ! [[ "$STABLE" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "❌ Derived stable version '$STABLE' is not valid x.y.z format"
-            exit 1
-          fi
           echo "✅ Version format valid: $ALPHA → $STABLE"
 
           # Alpha release must already exist in GitHub Releases

--- a/.github/workflows/promote-ga-charts.yaml
+++ b/.github/workflows/promote-ga-charts.yaml
@@ -1,0 +1,501 @@
+name: Promote Chart to Stable (GA)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Trigger: manual only, via GitHub Actions UI or API.
+# Only users listed in the PROMOTE_ALLOWED_USERS repository variable can run
+# this workflow. write access to the repository is also required to trigger
+# workflow_dispatch at all.
+# ─────────────────────────────────────────────────────────────────────────────
+on:
+  workflow_dispatch:
+    inputs:
+      chart:
+        description: 'Chart to promote to GA'
+        required: true
+        type: choice
+        options:
+          - tibco-cp-base
+          - tibco-cp-bw
+          - tibco-cp-flogo
+          - tibco-cp-devhub
+      pr:
+        description: 'PR number or full PR link (e.g. 123 or https://github.com/TIBCOSoftware/tp-helm-charts/pull/123)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    env:
+      REPO: ${{ github.repository }}
+
+    steps:
+
+      # ── 0. Authorization gate ─────────────────────────────────────────────
+      # Checks the triggering user against the comma-separated list stored in
+      # the PROMOTE_ALLOWED_USERS repository variable. Fails immediately if
+      # the actor is not on the list, preventing any further steps from running.
+      - name: Check authorized actor
+        run: |
+          IFS=',' read -ra ALLOWED <<< "${{ vars.PROMOTE_ALLOWED_USERS }}"
+          for user in "${ALLOWED[@]}"; do
+            [[ "${user// /}" == "${{ github.actor }}" ]] && {
+              echo "✅ ${{ github.actor }} is authorized to run this workflow"
+              exit 0
+            }
+          done
+          echo "❌ ${{ github.actor }} is not authorized to trigger this workflow"
+          echo "   Contact a repository admin to be added to the PROMOTE_ALLOWED_USERS variable"
+          exit 1
+
+      # ── Generate GitHub App token ─────────────────────────────────────────
+      # Creates a short-lived installation token (1 hr) scoped to tp-helm-charts.
+      # This is used for all gh CLI calls and the git checkout so that the merge
+      # commit triggers release-chart.yaml — pushes made by GITHUB_TOKEN are
+      # silently suppressed from triggering other workflows.
+      # Secrets required:
+      #   vars.PROMOTE_APP_ID          — the GitHub App's numeric ID
+      #   secrets.PROMOTE_APP_PRIVATE_KEY — the GitHub App's PEM private key
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.PROMOTE_APP_ID }}
+          private-key: ${{ secrets.PROMOTE_APP_PRIVATE_KEY }}
+          repositories: tp-helm-charts
+
+      - name: Export App token to GH_TOKEN
+        run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
+
+      # ── Record start time ────────────────────────────────────────────────
+      # Captured immediately after the authorization gate so the audit summary
+      # has an accurate timestamp regardless of how long subsequent steps take.
+      - name: Record start time
+        id: timing
+        run: |
+          echo "started_at=$(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_OUTPUT
+
+      # ── 1. Resolve PR number ──────────────────────────────────────────────
+      # Accepts both a raw integer (123) and a full GitHub PR URL.
+      # Extracts the numeric PR ID in either case.
+      - name: Resolve PR number
+        id: resolve
+        run: |
+          INPUT="${{ inputs.pr }}"
+          if [[ "$INPUT" =~ /pull/([0-9]+) ]]; then
+            PR="${BASH_REMATCH[1]}"
+          elif [[ "$INPUT" =~ ^[0-9]+$ ]]; then
+            PR="$INPUT"
+          else
+            echo "❌ Cannot parse a PR number from: $INPUT"
+            echo "   Provide either a PR number (e.g. 123) or a full PR URL"
+            exit 1
+          fi
+          echo "pr=$PR" >> $GITHUB_OUTPUT
+          echo "Resolved PR number: #$PR"
+
+      # ── 2. Validate PR state, label, and approvals ────────────────────────
+      # Three checks must all pass:
+      #   a) PR state must be OPEN
+      #   b) The 'chart-build' label must be applied (confirms alpha was published)
+      #   c) At least 2 approvals from collaborators with write/maintain/admin access
+      - name: Validate PR
+        id: pr
+        run: |
+          PR=${{ steps.resolve.outputs.pr }}
+          DATA=$(gh pr view "$PR" --repo "$REPO" \
+            --json state,labels,headRefName,reviews,title)
+
+          # (a) PR must be open
+          STATE=$(echo "$DATA" | jq -r '.state')
+          if [[ "$STATE" != "OPEN" ]]; then
+            echo "❌ PR #$PR is not open (current state: $STATE)"
+            echo "   This workflow only operates on open PRs"
+            exit 1
+          fi
+          echo "✅ PR #$PR is open"
+
+          # (b) 'chart-build' label must be present
+          HAS_LABEL=$(echo "$DATA" | jq -r '[.labels[].name] | contains(["chart-build"])')
+          if [[ "$HAS_LABEL" != "true" ]]; then
+            echo "❌ Label 'chart-build' is not applied to PR #$PR"
+            echo "   Apply the 'chart-build' label and wait for the chart-build workflow"
+            echo "   to complete and publish the alpha release before running this workflow"
+            exit 1
+          fi
+          echo "✅ Label 'chart-build' is present"
+
+          # (c) At least 2 approvals from collaborators with write or higher access
+          APPROVED_USERS=$(echo "$DATA" | \
+            jq -r '[.reviews[] | {login: .author.login, state: .state, at: .submittedAt}]
+              | group_by(.login)
+              | map(sort_by(.at) | last)
+              | map(select(.state == "APPROVED"))
+              | .[].login')
+
+          WRITE_COUNT=0
+          for login in $APPROVED_USERS; do
+            PERM=$(gh api "repos/$REPO/collaborators/$login/permission" \
+              --jq '.permission' 2>/dev/null || echo "none")
+            if [[ "$PERM" == "write" || "$PERM" == "maintain" || "$PERM" == "admin" ]]; then
+              echo "  ✅ $login ($PERM access) — approval counted"
+              WRITE_COUNT=$((WRITE_COUNT + 1))
+            else
+              echo "  ⚠️  $login ($PERM access) — approval not counted (insufficient access level)"
+            fi
+          done
+
+          if [[ $WRITE_COUNT -lt 2 ]]; then
+            echo "❌ PR #$PR requires at least 2 approvals from collaborators with write access"
+            echo "   Found: $WRITE_COUNT qualifying approval(s)"
+            exit 1
+          fi
+          echo "✅ $WRITE_COUNT write-access approvals confirmed"
+
+          BRANCH=$(echo "$DATA" | jq -r '.headRefName')
+          PR_TITLE=$(echo "$DATA" | jq -r '.title')
+
+          # Strip [DO NOT MERGE] from title if present (case-insensitive)
+          CLEAN_TITLE=$(echo "$PR_TITLE" | sed 's/\[DO NOT MERGE\]//gI' | xargs)
+          if [[ "$CLEAN_TITLE" != "$PR_TITLE" ]]; then
+            echo "ℹ️  '[DO NOT MERGE]' found in PR title — will be removed before merge"
+            echo "   Before: $PR_TITLE"
+            echo "   After : $CLEAN_TITLE"
+          fi
+
+          echo "branch=$BRANCH"           >> $GITHUB_OUTPUT
+          echo "pr=$PR"                   >> $GITHUB_OUTPUT
+          echo "pr_title=$PR_TITLE"       >> $GITHUB_OUTPUT
+          echo "clean_title=$CLEAN_TITLE" >> $GITHUB_OUTPUT
+          echo "PR branch: $BRANCH"
+
+      # ── 3. Read and validate chart version ───────────────────────────────
+      # Fetches Chart.yaml from the PR branch via GitHub API (no local checkout
+      # required at this stage). Validates that:
+      #   - The version field follows the strict format: x.y.z-alpha.N
+      #   - The derived stable version follows x.y.z
+      #   - The alpha GitHub Release already exists (proving chart-build ran)
+      - name: Validate chart version
+        id: version
+        env:
+          BRANCH: ${{ steps.pr.outputs.branch }}
+        run: |
+          CHART="${{ inputs.chart }}"
+
+          RAW=$(gh api "repos/$REPO/contents/charts/$CHART/Chart.yaml?ref=$BRANCH" \
+            --jq '.content' | base64 -d)
+
+          ALPHA=$(echo "$RAW" | grep '^version:' | awk '{print $2}')
+          echo "Version found on PR branch: $ALPHA"
+
+          # Must strictly match x.y.z-alpha.N
+          if ! [[ "$ALPHA" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-alpha\.([0-9]+)$ ]]; then
+            echo "❌ Version '$ALPHA' does not match the required format: x.y.z-alpha.N"
+            echo "   Verify that Chart.yaml on branch '$BRANCH' has the correct pre-release version"
+            exit 1
+          fi
+
+          STABLE="${BASH_REMATCH[1]}"
+          echo "Target stable (GA) version: $STABLE"
+
+          # Validate derived stable version
+          if ! [[ "$STABLE" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "❌ Derived stable version '$STABLE' is not valid x.y.z format"
+            exit 1
+          fi
+          echo "✅ Version format valid: $ALPHA → $STABLE"
+
+          # Alpha release must already exist in GitHub Releases
+          ALPHA_TAG="$CHART-$ALPHA"
+          if ! gh release view "$ALPHA_TAG" --repo "$REPO" > /dev/null 2>&1; then
+            echo "❌ Alpha release '$ALPHA_TAG' not found in GitHub Releases"
+            echo "   The alpha chart must be published to GitHub Releases before promotion"
+            echo "   Steps to fix:"
+            echo "     1. Ensure label 'chart-build' is applied to PR #${{ steps.pr.outputs.pr }}"
+            echo "     2. Wait for the chart-build workflow to complete successfully"
+            echo "     3. Verify the release at: https://github.com/$REPO/releases/tag/$ALPHA_TAG"
+            echo "     4. Re-run this workflow"
+            exit 1
+          fi
+          echo "✅ Alpha release '$ALPHA_TAG' confirmed in GitHub Releases"
+
+          echo "alpha=$ALPHA"              >> $GITHUB_OUTPUT
+          echo "stable=$STABLE"            >> $GITHUB_OUTPUT
+          echo "alpha_tag=$ALPHA_TAG"      >> $GITHUB_OUTPUT
+          echo "stable_tag=$CHART-$STABLE" >> $GITHUB_OUTPUT
+
+      # ── 4. Checkout PR branch ────────────────────────────────────────────
+      # Uses the GitHub App token so that the version-bump push and subsequent
+      # merge trigger release-chart.yaml. Pushes made with GITHUB_TOKEN are
+      # suppressed from triggering other workflows.
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ steps.pr.outputs.branch }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      # ── 5. Strip alpha suffix — version field only ────────────────────────
+      # Makes exactly one targeted change: the `version:` line in Chart.yaml.
+      # A strict safety guard verifies that exactly one file changed and
+      # exactly two diff lines were produced (the removed alpha line and the
+      # added stable line). Any deviation fails the workflow.
+      - name: Strip alpha suffix from Chart.yaml
+        run: |
+          CHART="${{ inputs.chart }}"
+          ALPHA="${{ steps.version.outputs.alpha }}"
+          STABLE="${{ steps.version.outputs.stable }}"
+          FILE="charts/$CHART/Chart.yaml"
+
+          ALPHA_ESC=$(printf '%s' "$ALPHA" | sed 's/[.[\*^$]/\\&/g')
+          sed -i "s/^version: ${ALPHA_ESC}$/version: ${STABLE}/" "$FILE"
+
+          CHANGED_FILES=$(git diff --name-only)
+          DIFF_LINES=$(git diff --unified=0 | grep '^[+-]' | grep -vc '^---\|^+++' || true)
+
+          if [[ "$CHANGED_FILES" != "$FILE" ]]; then
+            echo "❌ Unexpected files changed: '$CHANGED_FILES'"
+            echo "   Only charts/$CHART/Chart.yaml should be modified"
+            git diff
+            exit 1
+          fi
+
+          if [[ "$DIFF_LINES" -ne 2 ]]; then
+            echo "❌ Expected exactly 2 diff lines (one removed, one added), found: $DIFF_LINES"
+            git diff
+            exit 1
+          fi
+
+          echo "✅ Exactly one change confirmed:"
+          git diff
+
+      # ── 6. Update artifact files if present in the PR ───────────────────
+      # Artifact files live under artifacts/ and follow the format:
+      #   <chart-name>:<version>   (one entry per line)
+      # Example: tibco-cp-base:1.17.0-alpha.112
+      #
+      # This step:
+      #   1. Identifies which artifact files were changed in this PR
+      #   2. Checks if any contain the exact entry <chart>:<alpha-version>
+      #   3. Replaces it with <chart>:<stable-version> in those files
+      #   4. Reports which files were updated (or skips cleanly if none matched)
+      #
+      # This step is informational — it does not fail the workflow if no
+      # matching artifact file is found, since not every PR touches artifacts.
+      - name: Update artifact files
+        id: artifacts
+        run: |
+          CHART="${{ inputs.chart }}"
+          ALPHA="${{ steps.version.outputs.alpha }}"
+          STABLE="${{ steps.version.outputs.stable }}"
+          ALPHA_ESC=$(printf '%s' "$ALPHA" | sed 's/[.[\*^$]/\\&/g')
+
+          # Find artifact files that were modified as part of this PR
+          git fetch origin main --depth=1 2>/dev/null || true
+          CHANGED_ARTIFACTS=$(git diff --name-only origin/main HEAD -- 'artifacts/' || true)
+
+          if [[ -z "$CHANGED_ARTIFACTS" ]]; then
+            echo "ℹ️  No artifact files were changed in this PR — skipping artifact update"
+            echo "updated=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Artifact files changed in this PR:"
+          echo "$CHANGED_ARTIFACTS"
+          echo ""
+
+          UPDATED=""
+          while IFS= read -r f; do
+            if [[ -f "$f" ]] && grep -q "^${CHART}:${ALPHA_ESC}$" "$f"; then
+              sed -i "s/^${CHART}:${ALPHA_ESC}$/${CHART}:${STABLE}/" "$f"
+              UPDATED="$UPDATED $f"
+              echo "✅ $f"
+              echo "   ${CHART}:${ALPHA} → ${CHART}:${STABLE}"
+            else
+              echo "ℹ️  $f — no entry for '${CHART}:${ALPHA}', skipping"
+            fi
+          done <<< "$CHANGED_ARTIFACTS"
+
+          if [[ -z "$UPDATED" ]]; then
+            echo ""
+            echo "ℹ️  No artifact files contained '${CHART}:${ALPHA}' — nothing updated"
+            echo "updated=false" >> $GITHUB_OUTPUT
+          else
+            UPDATED_TRIMMED="${UPDATED# }"   # strip leading space
+            echo "updated=true" >> $GITHUB_OUTPUT
+            echo "artifact_files=${UPDATED_TRIMMED// /,}" >> $GITHUB_OUTPUT
+            echo "artifact_change=${CHART}:${ALPHA} → ${CHART}:${STABLE}" >> $GITHUB_OUTPUT
+          fi
+
+      # ── 7. Remove chart-build label ──────────────────────────────────────
+      # Must happen BEFORE the version-bump commit is pushed (step 8).
+      # The chart-build label triggers release-chart-label.yaml on push events.
+      # If the label is still present when we push the GA version to the PR
+      # branch, that workflow fires and builds the chart before the PR merges —
+      # producing an incorrectly-triggered release. Removing it first prevents
+      # that. The release-chart.yaml workflow (triggered on push to main after
+      # merge) is what publishes the GA chart correctly.
+      - name: Remove chart-build label
+        run: |
+          gh pr edit "${{ steps.pr.outputs.pr }}" \
+            --repo "$REPO" \
+            --remove-label "chart-build"
+          echo "✅ Removed 'chart-build' label from PR #${{ steps.pr.outputs.pr }}"
+
+      # ── 8. Commit and push ──────────────────────────────────────────────
+      - name: Commit version change
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "charts/${{ inputs.chart }}/Chart.yaml"
+          if [[ "${{ steps.artifacts.outputs.updated }}" == "true" ]]; then
+            git add artifacts/
+            echo "Including artifact file updates in commit"
+          fi
+          git commit -m "chore: promote ${{ inputs.chart }} ${{ steps.version.outputs.alpha }} → ${{ steps.version.outputs.stable }}"
+          git push
+
+      # ── 9. Clean PR title ────────────────────────────────────────────────
+      # Removes [DO NOT MERGE] from the PR title if present before merging.
+      # PRs are often marked [DO NOT MERGE] during development as a safety
+      # guard. The promotion workflow is the signal that the chart is ready —
+      # the title is cleaned automatically so the merge commit is presentable.
+      - name: Clean PR title
+        env:
+          PR_TITLE: ${{ steps.pr.outputs.pr_title }}
+          CLEAN_TITLE: ${{ steps.pr.outputs.clean_title }}
+        run: |
+          if [[ "$CLEAN_TITLE" != "$PR_TITLE" ]]; then
+            gh pr edit "${{ steps.pr.outputs.pr }}" \
+              --repo "$REPO" \
+              --title "$CLEAN_TITLE"
+            echo "✅ PR title updated: '$PR_TITLE' → '$CLEAN_TITLE'"
+          else
+            echo "ℹ️  PR title has no [DO NOT MERGE] marker — no change needed"
+          fi
+
+      # ── 10. Squash and merge PR ──────────────────────────────────────────
+      # Squash merge produces a single clean commit on the target branch.
+      # Branch deletion is handled automatically by the repository setting
+      # "Automatically delete head branches" — no --delete-branch flag needed.
+      - name: Squash and merge PR
+        run: |
+          gh pr merge "${{ steps.pr.outputs.pr }}" \
+            --repo "$REPO" \
+            --squash \
+            --auto \
+            --subject "chore: release ${{ inputs.chart }} ${{ steps.version.outputs.stable }}"
+
+      # ── 11. Poll until GA GitHub Release is available ────────────────────
+      # Polls for the GitHub Release tag created by release-chart.yaml.
+      # That workflow runs asynchronously after the merge — polling is the only
+      # way to confirm it completed. Timeout: 5 minutes, interval: 15s.
+      - name: Wait for GA chart availability
+        run: |
+          STABLE_TAG="${{ steps.version.outputs.stable_tag }}"
+          MAX=300
+          TICK=15
+          ELAPSED=0
+
+          echo "Polling for GitHub Release '$STABLE_TAG' (timeout: ${MAX}s, interval: ${TICK}s)..."
+          echo ""
+
+          while [[ $ELAPSED -lt $MAX ]]; do
+            if gh release view "$STABLE_TAG" --repo "$REPO" > /dev/null 2>&1; then
+              echo "✅ GitHub Release '$STABLE_TAG' is live"
+              echo "   https://github.com/$REPO/releases/tag/$STABLE_TAG"
+              exit 0
+            fi
+            echo "  ⏳ Not yet available — ${ELAPSED}s / ${MAX}s elapsed, retrying in ${TICK}s..."
+            sleep $TICK
+            ELAPSED=$((ELAPSED + TICK))
+          done
+
+          echo "❌ Timed out after ${MAX}s — release not yet published"
+          echo "   Investigate: https://github.com/$REPO/actions/workflows/release-chart.yaml"
+          exit 1
+
+      # ── 12. Audit summary ─────────────────────────────────────────────────
+      # Runs unconditionally (if: always()) so it captures the full audit trail
+      # even when earlier steps fail. Writes a rendered markdown table to the
+      # GitHub Actions Job Summary — visible on the workflow run page under the
+      # "Summary" tab without needing to open individual step logs.
+      - name: Audit summary
+        if: always()
+        env:
+          PR_TITLE_ORIG: ${{ steps.pr.outputs.pr_title }}
+          PR_TITLE_CLEAN: ${{ steps.pr.outputs.clean_title }}
+        run: |
+          # Check GA release status at time of summary
+          STABLE_TAG="${{ steps.version.outputs.stable_tag }}"
+          GA_STATUS="⚠️ Not checked — workflow did not reach the release stage"
+
+          if [[ -n "$STABLE_TAG" ]]; then
+            if gh release view "$STABLE_TAG" --repo "$REPO" > /dev/null 2>&1; then
+              GA_STATUS="✅ [${STABLE_TAG}](https://github.com/$REPO/releases/tag/${STABLE_TAG}) published"
+            else
+              GA_STATUS="❌ Not yet available — check [release-chart workflow](${{ github.server_url }}/${{ github.repository }}/actions/workflows/release-chart.yaml)"
+            fi
+          fi
+
+          # Resolve fields with fallbacks for steps that may not have run
+          PR_NUM="${{ steps.pr.outputs.pr }}"
+          [[ -z "$PR_NUM" ]] && PR_NUM="${{ steps.resolve.outputs.pr }}"
+          [[ -z "$PR_NUM" ]] && PR_NUM="unknown"
+
+          BRANCH="${{ steps.pr.outputs.branch }}"
+          [[ -z "$BRANCH" ]] && BRANCH="unknown"
+
+          ALPHA="${{ steps.version.outputs.alpha }}"
+          [[ -z "$ALPHA" ]] && ALPHA="unknown"
+
+          STABLE="${{ steps.version.outputs.stable }}"
+          [[ -z "$STABLE" ]] && STABLE="unknown"
+
+          if [[ "${{ job.status }}" == "success" ]]; then
+            RESULT="✅ **Success** — GA chart promoted and confirmed"
+          else
+            RESULT="❌ **Failed** — review step logs for details"
+          fi
+
+          PR_LINK="#${PR_NUM}"
+          if [[ "$PR_NUM" != "unknown" ]]; then
+            PR_LINK="[#${PR_NUM}](${{ github.server_url }}/${{ github.repository }}/pull/${PR_NUM})"
+          fi
+
+          # PR_TITLE_ORIG and PR_TITLE_CLEAN are injected via env: above (not
+          # via ${{ }} in the run block) to prevent script injection from
+          # attacker-controlled PR title values.
+
+          {
+            echo "## 🔖 Chart Promotion Audit"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| **Triggered by** | \`${{ github.actor }}\` |"
+            echo "| **Triggered at** | \`${{ steps.timing.outputs.started_at }}\` |"
+            echo "| **Workflow run** | [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |"
+            echo "| **Chart** | \`${{ inputs.chart }}\` |"
+            echo "| **PR** | ${PR_LINK} |"
+            echo "| **PR branch** | \`${BRANCH}\` |"
+            if [[ -n "$PR_TITLE_ORIG" && "$PR_TITLE_ORIG" != "$PR_TITLE_CLEAN" ]]; then
+              echo "| **PR title (before)** | \`${PR_TITLE_ORIG}\` |"
+              echo "| **PR title (after)** | \`${PR_TITLE_CLEAN}\` |"
+            elif [[ -n "$PR_TITLE_CLEAN" ]]; then
+              echo "| **PR title** | \`${PR_TITLE_CLEAN}\` |"
+            fi
+            echo "| **Version before (alpha)** | \`${ALPHA}\` |"
+            echo "| **Version after (GA)** | \`${STABLE}\` |"
+            echo "| **GA release** | ${GA_STATUS} |"
+            if [[ "${{ steps.artifacts.outputs.updated }}" == "true" ]]; then
+              ARTIFACT_FILES="${{ steps.artifacts.outputs.artifact_files }}"
+              ARTIFACT_CHANGE="${{ steps.artifacts.outputs.artifact_change }}"
+              echo "| **Artifact file(s) updated** | \`${ARTIFACT_FILES//,/\`, \`}\` |"
+              echo "| **Artifact change** | \`${ARTIFACT_CHANGE}\` |"
+            else
+              echo "| **Artifact files** | ℹ️ Not present in PR — no update needed |"
+            fi
+            echo "| **Result** | ${RESULT} |"
+          } >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
  ## Summary

  Adds a manual GitHub Actions workflow to promote Helm charts from pre-release
  (alpha) to GA stable versions in a controlled, auditable way.

  ### What it does

  - Triggered manually (`workflow_dispatch`) by authorized users only
  - Accepts a chart name (dropdown) and PR number/link as inputs
  - Validates all pre-conditions before making any changes:
    - PR is open, has `chart-build` label, and has ≥ 2 write-access approvals
    - Chart version on the PR branch matches `x.y.z-alpha.N`
    - Alpha GitHub Release already exists
  - Makes exactly one version change: strips `-alpha.N` from `Chart.yaml`
  - Updates artifact files under `artifacts/` if the PR touched them
  - Removes the `chart-build` label before pushing (prevents premature chart build)
  - Strips `[DO NOT MERGE]` from PR title if present
  - Squash-merges the PR using a GitHub App token (ensures `release-chart.yaml`
    fires on merge — `GITHUB_TOKEN` would suppress it)
  - Polls for the GA GitHub Release for up to 5 minutes to confirm publication
  - Writes a full audit summary to the GitHub Actions Job Summary on every run,
    including failures

  ### Prerequisites (to be configured before first run)

  - GitHub App installed on this repo with Contents R/W and Pull requests R/W
  - `PROMOTE_APP_ID` repository variable
  - `PROMOTE_APP_PRIVATE_KEY` repository secret
  - `PROMOTE_ALLOWED_USERS` repository variable (comma-separated GitHub usernames)
  - "Allow auto-merge" enabled in repo Settings → General