### PR TITLE
Update promote-ga-charts.yaml - Fix issue with {{ }}

### DIFF
--- a/.github/workflows/promote-ga-charts.yaml
+++ b/.github/workflows/promote-ga-charts.yaml
@@ -462,7 +462,7 @@ jobs:
           fi
 
           # PR_TITLE_ORIG and PR_TITLE_CLEAN are injected via env: above (not
-          # via ${{ }} in the run block) to prevent script injection from
+          # via inline expressions in the run block) to prevent script injection from
           # attacker-controlled PR title values.
 
           {


### PR DESCRIPTION
This pull request makes a minor clarification to a comment in the `.github/workflows/promote-ga-charts.yaml` workflow file. The comment now specifies that `PR_TITLE_ORIG` and `PR_TITLE_CLEAN` are injected via `env:` above, rather than via inline expressions in the run block, to prevent script injection from attacker-controlled PR title values.