### PR TITLE
GA tag BW and flogo charts

### DIFF
--- a/artifacts/bw/bw-1.18.0-charts.txt
+++ b/artifacts/bw/bw-1.18.0-charts.txt
@@ -4,4 +4,4 @@ dp-bw-adapter:1.18.4
 dp-bw5ce-app:1.18.4
 dp-bwce-app:1.18.4
 dp-bwce-mon:1.18.3
-tibco-cp-bw:1.18.0-alpha.16
+tibco-cp-bw:1.18.0

--- a/artifacts/flogo/flogo-1.18.0-charts.txt
+++ b/artifacts/flogo/flogo-1.18.0-charts.txt
@@ -1,3 +1,3 @@
 dp-flogo-app:1.18.10
 flogoprovisioner:1.18.4
-tibco-cp-flogo:1.18.0-alpha.18
+tibco-cp-flogo:1.18.0

--- a/charts/tibco-cp-bw/Chart.yaml
+++ b/charts/tibco-cp-bw/Chart.yaml
@@ -4,7 +4,7 @@
 #
 apiVersion: v2
 name: tibco-cp-bw
-version: 1.18.0-alpha.16
+version: 1.18.0
 appVersion: 1.18.0
 description: TIBCO Controlplane chart for BW Capability
 dependencies:

--- a/charts/tibco-cp-flogo/Chart.yaml
+++ b/charts/tibco-cp-flogo/Chart.yaml
@@ -4,7 +4,7 @@
 #
 apiVersion: v2
 name: tibco-cp-flogo
-version: 1.18.0-alpha.18
+version: 1.18.0
 appVersion: 1.18.0
 description: TIBCO Controlplane chart for FLOGO Capability
 dependencies:


### PR DESCRIPTION
This pull request finalizes the release versions for both the BW and FLOGO Controlplane Helm charts and updates their references to use the stable (non-alpha) 1.18.0 versions. The main focus is to move from alpha pre-release versions to the official stable releases in both chart metadata and artifact references.

Version updates to stable releases:

* Updated `tibco-cp-bw` Helm chart version from `1.18.0-alpha.16` to `1.18.0` in `charts/tibco-cp-bw/Chart.yaml` and its artifact reference in `artifacts/bw/bw-1.18.0-charts.txt`. [[1]](diffhunk://#diff-7f37a6110acb14c56340d9bd1cfc6493f3a2ad38ba163386bf2a36013217a7faL7-R7) [[2]](diffhunk://#diff-02fe52f336cfbdfdc83081e410beab0d409bcb9bf2e291cd1d0067b11861909fL7-R7)
* Updated `tibco-cp-flogo` Helm chart version from `1.18.0-alpha.18` to `1.18.0` in `charts/tibco-cp-flogo/Chart.yaml` and its artifact reference in `artifacts/flogo/flogo-1.18.0-charts.txt`. [[1]](diffhunk://#diff-a988c9b3a9da6117b9f2498b51c39f25ae895265f5d1ad62b7b5219fe60724bdL7-R7) [[2]](diffhunk://#diff-7efbcafa3645a61adadba153da3d9822fec995df77608981a0c1fa192806f65cL3-R3)