### PR TITLE
wip/PCP-19274-I: Fix failure

### DIFF
--- a/.github/workflows/cleanup-alpha-chart-versions.yml
+++ b/.github/workflows/cleanup-alpha-chart-versions.yml
@@ -254,7 +254,7 @@ jobs:
           for CHART in $ALL_CHARTS; do
             # Alpha versions from tags
             grep "^${CHART}-" /tmp/all_tags.txt | grep -- "-alpha\." \
-              | sed "s/^${CHART}-//" | sort -V > /tmp/tag_vers.txt
+              | sed "s/^${CHART}-//" | sort -V > /tmp/tag_vers.txt || true
 
             # Alpha versions from index.yaml (yq env() avoids quoting issues with hyphens)
             export YQ_CHART="$CHART"
@@ -385,7 +385,7 @@ jobs:
               grep "^${CHART}-" /tmp/all_tags.txt | grep -- "-alpha\." \
                 | sed "s/^${CHART}-//" | while read -r VER; do
                   in_range "$VER" && echo "$VER"
-                done | sort -V > /tmp/range_tag_vers.txt
+                done | sort -V > /tmp/range_tag_vers.txt || true
 
               # Versions from index.yaml in range
               while read -r VER; do


### PR DESCRIPTION
This pull request makes minor improvements to the `cleanup-alpha-chart-versions.yml` workflow by ensuring that certain shell commands do not cause the workflow to fail if they encounter errors.

- Workflow robustness:
  * Added `|| true` to the end of commands that generate `/tmp/tag_vers.txt` and `/tmp/range_tag_vers.txt` to prevent the workflow from failing if no matching versions are found or if the command returns a non-zero exit code. [[1]](diffhunk://#diff-e7063b7aebd8374108c9fe41c5c037bf94fa2bf2cb9338a51002d5f9e55e6c74L257-R257) [[2]](diffhunk://#diff-e7063b7aebd8374108c9fe41c5c037bf94fa2bf2cb9338a51002d5f9e55e6c74L388-R388)