### PR TITLE
Fix branch name - use unique branch name to commit index.yaml

### DIFF
--- a/.github/workflows/cleanup-alpha-chart-versions.yml
+++ b/.github/workflows/cleanup-alpha-chart-versions.yml
@@ -568,7 +568,7 @@ jobs:
             exit 0
           fi
 
-          BRANCH="cleanup/alpha-${GITHUB_RUN_ID}"
+          BRANCH="alpha-versions-cleanup-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
           git checkout -b "$BRANCH"
           git add index.yaml
           git add -u  # stages any deleted .tgz files
@@ -609,6 +609,7 @@ jobs:
           gh pr merge "$PR_NUM" \
             --repo "$REPO" \
             --squash \
+            --delete-branch \
             --subject "chore: remove alpha versions from index.yaml (${{ env.VERSION_DISPLAY }})"
 
           MERGED_AT=$(gh pr view "$PR_NUM" --repo "$REPO" --json mergedAt --jq '.mergedAt' || true)


### PR DESCRIPTION
This pull request updates the workflow for cleaning up alpha chart versions to improve branch naming and automate branch deletion after merging pull requests. The most important changes are:

**Workflow improvements:**

* Changed the branch naming convention to include the GitHub run number and attempt, making branch names more unique and traceable (`BRANCH="alpha-versions-cleanup-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"`) (.github/workflows/cleanup-alpha-chart-versions.yml)
* Added the `--delete-branch` flag to the pull request merge command to automatically delete the cleanup branch after merging, reducing manual cleanup (.github/workflows/cleanup-alpha-chart-versions.yml)