### PR TITLE
Promote MCP server chart to production

### DIFF
--- a/charts/tp-dp-infra-mcp-server/Chart.yaml
+++ b/charts/tp-dp-infra-mcp-server/Chart.yaml
@@ -1,0 +1,29 @@
+# Copyright © 2026. Cloud Software Group, Inc.
+# This file is subject to the license terms contained
+# in the license file that is distributed with this file.
+#
+apiVersion: v2
+name: tp-dp-infra-mcp-server
+description: |
+  TIBCO® Platform Infra Model Context Protocol (MCP) Server for data plane.
+  Provides kubectl and helm command execution via MCP protocol
+  for AI-driven root cause analysis (TESSA).
+
+type: application
+version: 1.19.0
+appVersion: "1.0.0"
+
+keywords:
+  - tibco
+  - mcp
+  - data-plane
+  - kubernetes
+  - kubectl
+  - helm
+
+home: https://github.com/tibcosoftware/tp-helm-charts
+
+maintainers:
+  - name: TIBCO Platform Team
+
+kubeVersion: ">=1.21.0-0"

--- a/charts/tp-dp-infra-mcp-server/README.md
+++ b/charts/tp-dp-infra-mcp-server/README.md
@@ -1,0 +1,239 @@
+<!--
+ Copyright (c) 2026. Cloud Software Group, Inc.
+ This file is subject to the license terms contained
+ in the license file that is distributed with this file.
+-->
+
+# tp-dp-infra-mcp-server
+
+TIBCO® Platform Infra Model Context Protocol (MCP) Server for data plane. Provides read-only kubectl
+and helm command execution via [MCP protocol](https://modelcontextprotocol.io/)
+for AI-driven root cause analysis (TESSA).
+
+## Overview
+
+The TIBCO® Platform Infra Model Context Protocol (MCP) Server runs on each data plane and exposes two interfaces:
+
+| Port | Protocol | Purpose |
+|------|----------|---------|
+| 8091 (REST) | HTTP | REST API for kubectl/helm command execution |
+| 8092 (MCP)  | MCP  | Model Context Protocol for AI assistant integration |
+
+TESSA (TIBCO AI assistant) on the control plane reaches the MCP server
+through the dp-proxy pipeline:
+
+```
+TESSA -> platform-mcp-server (CP) -> dp-proxy -> HAProxy Ingress (DP) -> infra-mcp-server (DP)
+```
+
+## Prerequisites
+
+| Requirement | Details |
+|-------------|---------|
+| Kubernetes | >= 1.21.0 |
+| Helm | >= 3.14 |
+| `dp-configure-namespace` chart | Installed in each DP namespace (creates RBAC) |
+| `dp-core-infrastructure` chart | >= 1.15.0 |
+
+## Installation
+
+This chart is deployed as a platform capability through the TIBCO Platform
+Control Plane. It is not typically installed manually.
+
+To provision via the CP UI:
+1. Navigate to **Data Planes > Capabilities > Add Capability**
+2. Select **TIBCO® Platform Infra Model Context Protocol (MCP) Server**
+3. Configure service account and logging options
+4. Review the recipe YAML and provision
+
+### Manual installation (dev/test)
+
+```bash
+helm install tp-dp-infra-mcp-server charts/tp-dp-infra-mcp-server \
+  --namespace <dp-namespace> \
+  --set global.cp.dataplaneId=<dataplane-id> \
+  --set global.cp.instanceId=<instance-id> \
+  --set global.cp.containerRegistry.url=<registry-url> \
+  --set image.tag=<image-tag>
+```
+
+## Architecture
+
+### Charts involved
+
+Two charts collaborate to deploy the infra-mcp-server:
+
+| Chart | Responsibility | When it runs |
+|-------|---------------|--------------|
+| `dp-configure-namespace` | Creates RBAC (Role/ClusterRole + Bindings) and a provisioner Role | Data plane bootstrap (before any capability) |
+| `tp-dp-infra-mcp-server` | Creates ServiceAccount (unless BYOSA), Deployment, Service, Ingress | Capability provisioning |
+
+This separation ensures RBAC is managed by infrastructure operators while
+the capability chart only handles workload resources.
+
+### Resources created by this chart
+
+| Resource | Name | Description |
+|----------|------|-------------|
+| Deployment | `tp-dp-infra-mcp-server` | Single-replica pod with REST + MCP ports |
+| Service | `tp-dp-infra-mcp-server` | ClusterIP with ports `rest` (80->8091) and `mcp` (8092->8092) |
+| ServiceAccount | `tp-dp-infra-mcp-server` | Created when `serviceAccount.create: true` |
+| ConfigMap | `tp-dp-infra-mcp-server-config` | kubectl/helm security policies (allowlists) |
+| Ingress (HAProxy) | `haproxy-infra-mcp-server` | Private CP-to-DP ingress to the REST service port (enabled by default; the only ingress this chart creates) |
+| FluentBit ConfigMap | `tp-dp-infra-mcp-server-fluentbit-config` | Optional sidecar logging config |
+
+## Service Account & RBAC
+
+Three modes are supported. See [docs/service-account-design.md](docs/service-account-design.md) for detailed diagrams.
+
+### Mode 1 -- Default (namespace-scoped)
+
+Standard deployment. Pod can read resources within its data plane namespace(s).
+
+```yaml
+# dp-configure-namespace values
+rbac:
+  infraMcp: true
+  infraMcpClusterScoped: false       # namespace-scoped (default)
+
+# tp-dp-infra-mcp-server values
+serviceAccount:
+  create: true                     # chart creates SA (default)
+```
+
+### Mode 2 -- Cluster-scoped
+
+Full cluster diagnostics. Pod can read resources across all namespaces.
+
+```yaml
+# dp-configure-namespace values
+rbac:
+  infraMcp: true
+  infraMcpClusterScoped: true        # cluster-wide access
+
+# tp-dp-infra-mcp-server values
+serviceAccount:
+  create: true
+```
+
+### Mode 3 -- BYOSA (Bring Your Own Service Account)
+
+Customer pre-creates their own SA with custom RBAC.
+
+```yaml
+# dp-configure-namespace values
+rbac:
+  infraMcp: false                    # skip RBAC creation
+
+# tp-dp-infra-mcp-server values
+serviceAccount:
+  create: false                    # don't create SA
+  name: "my-custom-sa"            # use pre-existing SA
+```
+
+### RBAC permissions (Modes 1 & 2)
+
+The read-only Role/ClusterRole grants access to:
+
+| API Group | Resources | Verbs |
+|-----------|-----------|-------|
+| `""` (core) | pods, pods/log, services, endpoints, configmaps, secrets, events, PVCs | get, list, watch |
+| `apps` | deployments, replicasets, statefulsets, daemonsets | get, list, watch |
+| `batch` | jobs, cronjobs | get, list, watch |
+| `autoscaling` | horizontalpodautoscalers | get, list, watch |
+| `networking.k8s.io` | ingresses, networkpolicies | get, list, watch |
+| `metrics.k8s.io` | pods (+ nodes in cluster-scoped) | get, list |
+
+Additional resources in cluster-scoped mode: `namespaces`, `nodes`.
+
+Custom rules can be appended via `rbac.infraMcpExtraRules` in dp-configure-namespace.
+
+### Multi-namespace data planes
+
+When a data plane spans multiple namespaces, `dp-configure-namespace` creates
+a Role + RoleBinding in **every** DP namespace. Additional namespaces use
+cross-namespace subject references to point to the SA in the primary namespace:
+
+```yaml
+# RoleBinding in additional namespace
+subjects:
+- kind: ServiceAccount
+  name: tp-dp-infra-mcp-server
+  namespace: <primary-namespace>    # cross-namespace reference
+```
+
+## Security
+
+### Command allowlisting
+
+The ConfigMap defines strict allowlists for kubectl and helm:
+
+| Tool | Allowed | Blocked |
+|------|---------|---------|
+| kubectl | `get`, `describe`, `logs` | `delete`, `create`, `apply`, `patch`, `edit`, `replace`, `exec`, `drain`, `cordon`, `taint` |
+| helm | `list`, `status`, `get`, `history` | `install`, `upgrade`, `uninstall`, `delete`, `rollback` |
+
+### Pod security
+
+- Runs as non-root (UID 1000)
+- Read-only root filesystem
+- All capabilities dropped
+- Seccomp profile: RuntimeDefault
+- No privilege escalation
+
+### Provisioner Role (least-privilege)
+
+The `dp-configure-namespace` chart creates a provisioner Role that allows
+the shared DP service account to manage only the infra-mcp-server's SA:
+
+- `create` -- unrestricted (Kubernetes limitation: `resourceNames` doesn't apply to create)
+- `get`, `update`, `delete` -- restricted to the specific SA name via `resourceNames`
+
+## Configuration
+
+### Key values
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `serviceAccount.create` | `true` | Create a dedicated ServiceAccount |
+| `serviceAccount.name` | `""` | Override SA name (defaults to chart fullname) |
+| `image.tag` | `"70"` | Container image tag |
+| `config.LOG_LEVEL` | `"info"` | Application log level |
+| `config.KUBECTL_TIMEOUT` | `"30"` | kubectl command timeout (seconds) |
+| `config.HELM_TIMEOUT` | `"30"` | helm command timeout (seconds) |
+| `haproxy.enabled` | `true` | Enable HAProxy ingress for CP-to-DP routing |
+| `haproxy.pathPrefix` | `/tibco/agent/integration/infra-mcp-server` | HAProxy path prefix |
+| `global.cp.logging.fluentbit.enabled` | `false` | Enable FluentBit sidecar for log shipping |
+| `global.cp.enableResourceConstraints` | `true` | Apply CPU/memory limits |
+
+### Resource constraints
+
+When `global.cp.enableResourceConstraints: true` (default):
+
+| Container | CPU Request | CPU Limit | Memory Request | Memory Limit |
+|-----------|-------------|-----------|----------------|--------------|
+| infra-mcp-server | 100m | 500m | 128Mi | 512Mi |
+| fluentbit (optional) | 10m | 50m | 15Mi | 30Mi |
+
+## Observability
+
+When `global.cp.logging.fluentbit.enabled: true`, a FluentBit sidecar is
+added to the pod. It collects application logs and ships them to the
+OpenTelemetry collector at `otel-services.<namespace>.svc.cluster.local:4318`.
+
+## Recipe registration
+
+The capability is registered in the CP via a recipe in `tp-cp-configuration`.
+Capability name: `inframcpserver`. Provisioning role: `DEV_OPS`.
+
+The recipe includes:
+- Chart version and image tag references
+- Data plane identity variables (`${DATAPLANE_ID}`, `${NAMESPACE}`)
+- Service account configuration from the provisioning UI
+- Optional FluentBit sidecar configuration
+
+## Related resources
+
+- [Service Account & RBAC Design](docs/service-account-design.md) -- detailed RBAC design with diagrams
+- [dp-configure-namespace](../dp-configure-namespace/) -- infrastructure chart that creates RBAC
+- [MCP Protocol specification](https://modelcontextprotocol.io/)

--- a/charts/tp-dp-infra-mcp-server/templates/_helpers.tpl
+++ b/charts/tp-dp-infra-mcp-server/templates/_helpers.tpl
@@ -1,0 +1,69 @@
+{{/*
+Copyright © 2026. Cloud Software Group, Inc.
+This file is subject to the license terms contained
+in the license file that is distributed with this file.
+*/}}
+
+{{/*
+Chart name and version for labels.
+*/}}
+{{- define "tp-infra-mcp-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Fullname — hardcoded, matching provisioner pattern.
+*/}}
+{{- define "tp-infra-mcp-server.fullname" }}tp-dp-infra-mcp-server{{ end -}}
+
+{{/*
+Common labels.
+*/}}
+{{- define "tp-infra-mcp-server.labels" -}}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ include "tp-infra-mcp-server.chart" . }}
+platform.tibco.com/capability: infra-mcp-server
+{{ include "tp-infra-mcp-server.selectorLabels" . }}
+{{- end }}
+
+{{/*
+Selector labels — includes platform-specific labels matching provisioner pattern.
+*/}}
+{{- define "tp-infra-mcp-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/part-of: "infra-mcp"
+platform.tibco.com/workload-type: "capability-service"
+platform.tibco.com/dataplane-id: {{ .Values.global.cp.dataplaneId }}
+platform.tibco.com/capability-instance-id: {{ .Values.global.cp.instanceId }}
+{{- end }}
+
+{{/*
+ServiceAccount name — supports BYOSA (bring your own service account).
+*/}}
+{{- define "tp-infra-mcp-server.serviceAccountName" -}}
+{{- if .Values.serviceAccount.name -}}
+  {{- .Values.serviceAccount.name -}}
+{{- else -}}
+  {{- include "tp-infra-mcp-server.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+CP domain — cp-proxy service in the DP namespace.
+*/}}
+{{- define "tp-infra-mcp-server.cp.domain" }}cp-proxy.{{ .Values.global.cp.resources.serviceaccount.namespace }}.svc.cluster.local{{ end -}}
+
+{{/*
+Image registry.
+*/}}
+{{- define "tp-infra-mcp-server.image.registry" }}
+  {{- .Values.global.cp.containerRegistry.url }}
+{{- end -}}
+
+{{/*
+Image repository.
+*/}}
+{{- define "tp-infra-mcp-server.image.repository" -}}
+  {{- .Values.global.cp.containerRegistry.repository }}
+{{- end -}}

--- a/charts/tp-dp-infra-mcp-server/templates/configmap.yaml
+++ b/charts/tp-dp-infra-mcp-server/templates/configmap.yaml
@@ -1,0 +1,20 @@
+# Copyright © 2026. Cloud Software Group, Inc.
+# This file is subject to the license terms contained
+# in the license file that is distributed with this file.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tp-infra-mcp-server.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tp-infra-mcp-server.labels" . | nindent 4 }}
+data:
+  config.yaml: |-
+    kubectl:
+      allowedVerbs: ["get", "describe", "logs"]
+      allowedResources: ["pods", "services", "deployments", "statefulsets", "replicasets", "daemonsets", "jobs", "cronjobs", "configmaps", "events", "ingresses", "persistentvolumeclaims", "horizontalpodautoscalers", "endpoints", "networkpolicies"]
+      blockedVerbs: ["delete", "create", "apply", "patch", "edit", "replace", "exec", "drain", "cordon", "taint"]
+    helm:
+      allowedCommands: ["list", "status", "get", "history"]
+      blockedCommands: ["install", "upgrade", "uninstall", "delete", "rollback"]

--- a/charts/tp-dp-infra-mcp-server/templates/deployment.yaml
+++ b/charts/tp-dp-infra-mcp-server/templates/deployment.yaml
@@ -1,0 +1,128 @@
+# Copyright © 2026. Cloud Software Group, Inc.
+# This file is subject to the license terms contained
+# in the license file that is distributed with this file.
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tp-infra-mcp-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tp-infra-mcp-server.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "tp-infra-mcp-server.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "tp-infra-mcp-server.selectorLabels" . | nindent 8 }}
+        networking.platform.tibco.com/kubernetes-api: enable
+    spec:
+      imagePullSecrets:
+        - name: {{ .Values.global.cp.containerRegistry.secret }}
+      serviceAccountName: {{ include "tp-infra-mcp-server.serviceAccountName" . }}
+      automountServiceAccountToken: true
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: {{ include "tp-infra-mcp-server.image.registry" .}}{{"/"}}{{ include "tp-infra-mcp-server.image.repository" .}}{{"/"}}{{ .Values.image.name }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: rest
+              containerPort: {{ .Values.service.restTargetPort }}
+              protocol: TCP
+            - name: mcp
+              containerPort: {{ .Values.service.mcpTargetPort }}
+              protocol: TCP
+          env:
+            - name: CP_DOMAIN
+              value: {{ include "tp-infra-mcp-server.cp.domain" . }}
+            # The owning subscription, so the server can reject
+            # cross-subscription tokens (it requires this and fails fast without it).
+            - name: SUBSCRIPTION_ID
+              value: {{ required "global.cp.subscriptionId is required for tp-dp-infra-mcp-server" .Values.global.cp.subscriptionId | quote }}
+            {{- range $key, $val := .Values.config }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: rest
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: rest
+            initialDelaySeconds: 30
+            periodSeconds: 30
+{{- if .Values.global.cp.enableResourceConstraints }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+{{- end }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+{{- if .Values.global.cp.logging.fluentbit.enabled }}
+            - name: logs
+              mountPath: /var/log/pods
+{{- end }}
+{{- if .Values.global.cp.logging.fluentbit.enabled }}
+        - name: fluent-bit
+          image: {{ include "tp-infra-mcp-server.image.registry" .}}{{"/"}}{{ include "tp-infra-mcp-server.image.repository" .}}{{"/"}}common-fluentbit:{{ .Values.global.cp.logging.fluentbit.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.global.cp.logging.fluentbit.securityContext }}
+          securityContext:
+            {{- toYaml .Values.global.cp.logging.fluentbit.securityContext | nindent 12 }}
+          {{- end }}
+          {{- with .Values.global.cp.logging.fluentbit.probes.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.global.cp.enableResourceConstraints }}
+          {{- with .Values.global.cp.logging.fluentbit.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: CONTAINER_NAME
+              value: {{ .Chart.Name }}
+          volumeMounts:
+            - name: logs
+              mountPath: /var/log/pods
+            - name: fluent-bit-config
+              mountPath: /fluent-bit/etc/
+{{- end }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+{{- if .Values.global.cp.logging.fluentbit.enabled }}
+        - name: logs
+          emptyDir: {}
+        - name: fluent-bit-config
+          configMap:
+            name: {{ include "tp-infra-mcp-server.fullname" . }}-fluentbit-config
+{{- end }}

--- a/charts/tp-dp-infra-mcp-server/templates/fluentbit-configmap.yaml
+++ b/charts/tp-dp-infra-mcp-server/templates/fluentbit-configmap.yaml
@@ -1,0 +1,79 @@
+# Copyright © 2026. Cloud Software Group, Inc.
+# This file is subject to the license terms contained
+# in the license file that is distributed with this file.
+
+{{ if .Values.global.cp.logging.fluentbit.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tp-infra-mcp-server.fullname" . }}-fluentbit-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tp-infra-mcp-server.labels" . | nindent 4 }}
+data:
+  fluent-bit.conf: |
+    [SERVICE]
+      Flush             1
+      Log_Level         info
+      Daemon            off
+      Parsers_File      parsers.conf
+      HTTP_Server       On
+      HTTP_Listen       0.0.0.0
+      HTTP_Port         2020
+      Health_Check      On
+
+    @INCLUDE input.conf
+    @INCLUDE filter.conf
+    @INCLUDE output.conf
+
+  input.conf: |
+    [INPUT]
+      Name              tail
+      Tag               dp.${POD_NAMESPACE}.${POD_NAME}.${POD_ID}.${CONTAINER_NAME}
+      Path              /var/log/pods/tp-dp-infra-mcp-server.log
+      multiline.parser  docker, cri
+      DB                /var/log/pods/flb_kube.db
+      Mem_Buf_Limit     5MB
+      Skip_Long_Lines   On
+      Refresh_Interval  10
+
+  filter.conf: |
+    [FILTER]
+      Name              record_modifier
+      Match             dp.*
+      Remove_key        stream
+      Remove_key        _p
+
+    [FILTER]
+      Name              parser
+      Match             dp.*
+      Key_Name          log
+      Parser            json_decode
+      Reserve_Data      True
+
+  output.conf: |
+    [OUTPUT]
+      Name   stdout
+      Match  dp.*
+      Format json
+
+    [OUTPUT]
+      Name                 opentelemetry
+      Match                dp.*
+      Host                 otel-services.${POD_NAMESPACE}.svc.cluster.local
+      Port                 4318
+      Logs_uri             /v1/logs
+      Log_response_payload True
+      Tls                  Off
+      Tls.verify           Off
+
+  parsers.conf: |
+    [PARSER]
+      Name              json_decode
+      Format            regex
+      Regex             ^(?<log>.*)$
+      Time_Key          time
+      Time_Format       %Y-%m-%dT%H:%M:%S.%L
+      Time_Keep         On
+      Decode_Field_As   json log
+{{- end }}

--- a/charts/tp-dp-infra-mcp-server/templates/haproxy-ingress.yaml
+++ b/charts/tp-dp-infra-mcp-server/templates/haproxy-ingress.yaml
@@ -1,0 +1,31 @@
+# Copyright © 2026. Cloud Software Group, Inc.
+# This file is subject to the license terms contained
+# in the license file that is distributed with this file.
+#
+{{- if .Values.haproxy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: haproxy-infra-mcp-server
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tp-infra-mcp-server.labels" . | nindent 4 }}
+  annotations:
+    haproxy.org/cors-enable: "true"
+    haproxy.org/load-balance: leastconn
+    haproxy.org/src-ip-header: X-Real-IP
+    ingress.kubernetes.io/path-rewrite: {{ .Values.haproxy.pathPrefix }}/(.*) /\1
+spec:
+  ingressClassName: tibco-dp-{{ .Values.global.cp.dataplaneId }}
+  rules:
+    - host: {{ tpl .Values.global.cp.dpUrl.host . }}
+      http:
+        paths:
+          - path: {{ .Values.haproxy.pathPrefix }}/
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "tp-infra-mcp-server.fullname" . }}
+                port:
+                  number: {{ .Values.service.restPort }}
+{{- end }}

--- a/charts/tp-dp-infra-mcp-server/templates/service.yaml
+++ b/charts/tp-dp-infra-mcp-server/templates/service.yaml
@@ -1,0 +1,24 @@
+# Copyright © 2026. Cloud Software Group, Inc.
+# This file is subject to the license terms contained
+# in the license file that is distributed with this file.
+#
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tp-infra-mcp-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tp-infra-mcp-server.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "tp-infra-mcp-server.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: rest
+      port: {{ .Values.service.restPort }}
+      targetPort: {{ .Values.service.restTargetPort }}
+      protocol: TCP
+    - name: mcp
+      port: {{ .Values.service.mcpPort }}
+      targetPort: {{ .Values.service.mcpTargetPort }}
+      protocol: TCP

--- a/charts/tp-dp-infra-mcp-server/templates/serviceaccount.yaml
+++ b/charts/tp-dp-infra-mcp-server/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+# Copyright © 2026. Cloud Software Group, Inc.
+# This file is subject to the license terms contained
+# in the license file that is distributed with this file.
+#
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tp-infra-mcp-server.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tp-infra-mcp-server.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/tp-dp-infra-mcp-server/values.yaml
+++ b/charts/tp-dp-infra-mcp-server/values.yaml
@@ -1,0 +1,118 @@
+# Copyright © 2026. Cloud Software Group, Inc.
+# This file is subject to the license terms contained
+# in the license file that is distributed with this file.
+
+global:
+  cp:
+    dataplaneId: ""
+    instanceId: ""
+    # CP-DP HAProxy ingress vhost. Default = tunnel vhost (hybrid-ON).
+    # The orchestrator overrides host with the reachable-URL host
+    # (cpdpproxy.<dp-ns>.svc.cluster.local) when hybrid connectivity is disabled,
+    # exactly as for bwprovisioner/flogoprovisioner/o11y-service/tp-dp-mcp-gateway.
+    # Rendered through `tpl` in haproxy-ingress.yaml so the {{ }} default is
+    # re-evaluated at install. Keys on global.cp.dataplaneId — the same identifier
+    # this chart's ingressClassName (tibco-dp-<dataplaneId>) already uses.
+    dpUrl:
+      host: "dp-{{ $.Values.global.cp.dataplaneId }}.platform.local"
+      port: 443
+    containerRegistry:
+      secret: ""
+      url: ""
+      repository: "tibco-platform-docker-prod"
+    enableResourceConstraints: true
+    resources:
+      serviceaccount:
+        namespace: ""
+        serviceAccountName: ""
+    logging:
+      fluentbit:
+        enabled: false
+        image:
+          tag: 5.0.2
+        resources:
+          requests:
+            cpu: 10m
+            memory: 15Mi
+          limits:
+            cpu: 50m
+            memory: 30Mi
+        probes:
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /api/v1/health
+              port: 2020
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+
+# -- Service account configuration
+serviceAccount:
+  # Set to false to use a pre-existing service account (BYOSA)
+  create: true
+  # Override the service account name (defaults to chart fullname)
+  name: ""
+
+# -- Container image
+image:
+  name: tp-infra-mcp-server
+  tag: "70"
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+# -- Service ports
+service:
+  type: ClusterIP
+  restPort: 80
+  restTargetPort: 8091
+  mcpPort: 8092
+  mcpTargetPort: 8092
+
+# -- HAProxy ingress for CP-to-DP proxy routing
+haproxy:
+  enabled: true
+  pathPrefix: /tibco/agent/integration/infra-mcp-server
+
+# -- Application configuration (mounted as environment variables)
+config:
+  LOG_LEVEL: "info"
+  KUBECTL_TIMEOUT: "30"
+  HELM_TIMEOUT: "30"
+
+# -- Resource constraints
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+# -- Pod security context
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+# -- Container security context
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL


### PR DESCRIPTION
This pull request introduces a new Helm chart, `tp-dp-infra-mcp-server`, which deploys the TIBCO® Platform Infra Model Context Protocol (MCP) Server for the data plane. The chart provides all the necessary Kubernetes resources, configuration, and documentation to support read-only `kubectl` and `helm` command execution for AI-driven root cause analysis (TESSA). The implementation emphasizes security, RBAC flexibility, and observability, and includes comprehensive documentation for operators.

The most important changes are:

**New Helm Chart: tp-dp-infra-mcp-server**

* Added a new chart definition (`Chart.yaml`) with metadata, versioning, maintainers, and Kubernetes version requirements.
* Provided a detailed `README.md` explaining architecture, installation, RBAC/service account modes, security, configuration options, observability, and related resources.

**Kubernetes Resource Templates**

* Implemented templates for all required resources:
  - Deployment with support for resource constraints, sidecar logging, and environment configuration (`deployment.yaml`).
  - Service exposing REST and MCP ports (`service.yaml`).
  - ConfigMap for command allowlisting (`configmap.yaml`).
  - ServiceAccount with BYOSA support (`serviceaccount.yaml`).
  - Optional FluentBit ConfigMap for log shipping (`fluentbit-configmap.yaml`).
  - HAProxy Ingress for CP-to-DP routing (`haproxy-ingress.yaml`).

**Theming and Reusability**

* Added a `_helpers.tpl` file with reusable Helm template helpers for consistent naming, labeling, and image registry configuration.

**Security and Observability**

* Enforced strict allowlists for `kubectl` and `helm` commands, non-root pod execution, and optional FluentBit sidecar for observability. [[1]](diffhunk://#diff-12ec92cf60a52d13cc53775fc17bb46449fa35091d735fc70604445c4a308d54R1-R20) [[2]](diffhunk://#diff-baa2d8f875dc15f49c54af5806b2f282e82f5edb17c9c930046f26ab48aad971R1-R79)

These changes collectively establish a secure, observable, and flexible deployment for the infra MCP server as a data plane capability.